### PR TITLE
Feat: 소분류 카테고리에 속하는 식재료 리스트 및 개수 조회 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/converter/IngredientConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/IngredientConverter.java
@@ -1,8 +1,12 @@
 package com.backend.DuruDuru.global.converter;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class IngredientConverter {
 
@@ -37,6 +41,23 @@ public class IngredientConverter {
                 .build();
     }
 
+    public static IngredientResponseDTO.IngredientDetailDTO toIngredientDetailDTO(Ingredient ingredient) {
+        return IngredientResponseDTO.IngredientDetailDTO.builder()
+                .memberId(ingredient.getMember().getMemberId())
+                .fridgeId(ingredient.getFridge().getFridgeId())
+                .ingredientId(ingredient.getIngredientId())
+                .ingredientName(ingredient.getIngredientName())
+                .count(ingredient.getCount())
+                .purchaseDate(ingredient.getPurchaseDate())
+                .expiryDate(ingredient.getExpiryDate())
+                .storageType(String.valueOf(ingredient.getStorageType()))
+                .majorCategory(ingredient.getMajorCategory().name())
+                .minorCategory(ingredient.getMinorCategory().name())
+                .ingredientImageUrl(ingredient.getIngredientImg().getIngredientImgUrl())
+                .createdAt(ingredient.getCreatedAt())
+                .updatedAt(ingredient.getUpdatedAt())
+                .build();
+    }
 
     public static IngredientResponseDTO.PurchaseDateResultDTO toPurchaseDateResultDTO(Ingredient ingredient) {
         return IngredientResponseDTO.PurchaseDateResultDTO.builder()
@@ -81,4 +102,15 @@ public class IngredientConverter {
                 .build();
     }
 
+
+    public static IngredientResponseDTO.MinorCategoryIngredientPreviewListDTO toMinorCategoryIngredientPreviewListDTO(
+            MinorCategory minorCategory, List<Ingredient> ingredients) {
+        return IngredientResponseDTO.MinorCategoryIngredientPreviewListDTO.builder()
+                .minorCategory(minorCategory.name())
+                .count(ingredients.size())
+                .ingredients(ingredients.stream()
+                        .map(IngredientConverter::toIngredientDetailDTO)
+                        .collect(Collectors.toList()))
+                .build();
+    }
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -1,7 +1,13 @@
 package com.backend.DuruDuru.global.repository;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+
+    List<Ingredient> findByMember_MemberIdAndMinorCategory(Long memberId, MinorCategory minorCategory);
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryService.java
@@ -1,11 +1,14 @@
 package com.backend.DuruDuru.global.service.IngredientService;
 
+import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
+import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 
+import java.util.List;
 import java.util.Map;
 
 public interface IngredientQueryService {
     // 대분류에 따른 소분류 가져오기
     Map<String, Object> getMinorCategoriesByMajor(MajorCategory majorCategory);
-
+    List<Ingredient> getIngredientsByMinorCategory(Long memberId, MinorCategory minorCategory);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryServiceImpl.java
@@ -3,8 +3,10 @@ package com.backend.DuruDuru.global.service.IngredientService;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
+import com.backend.DuruDuru.global.repository.IngredientRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @Slf4j
 public class IngredientQueryServiceImpl implements IngredientQueryService {
+    private final IngredientRepository ingredientRepository;
 
     @Override
     public Map<String, Object> getMinorCategoriesByMajor(MajorCategory majorCategory) {
@@ -29,6 +32,12 @@ public class IngredientQueryServiceImpl implements IngredientQueryService {
         result.put("minorCategoryList", minorCategoryList);
 
         return result;
+    }
+
+    @Override
+    public List<Ingredient> getIngredientsByMinorCategory(Long memberId, MinorCategory minorCategory) {
+        //소분류 카테고리에 속하는 식재료 조회
+        return ingredientRepository.findByMember_MemberIdAndMinorCategory(memberId, minorCategory);
     }
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.parameters.P;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.management.relation.InvalidRelationIdException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -160,18 +161,21 @@ public class IngredientController {
 
     // 소분류 카테고리에 속하는 식재료 리스트 조회
     @GetMapping("/search/category/list")
-    @Operation(summary = "식재료 카테고리로 검색 API", description = "식재료를 카테고리로 검색하는 API 입니다. 입력된 카테고리에 속한 식재료를 모두 반환합니다.")
-    public ApiResponse<?> searchIngredientByCategory(){
-        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, null);
+    @Operation(summary = "소분류 카테고리에 속하는 식재료 리스트 조회 API", description = "식재료를 카테고리로 검색하는 API 입니다. 입력된 카테고리에 속한 식재료를 모두 반환합니다.")
+    public ApiResponse<IngredientResponseDTO.MinorCategoryIngredientPreviewListDTO> searchIngredientByMinorCategory(@RequestParam Long memberId,
+                                                                                                                    @RequestParam MinorCategory minorCategory) {
+        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByMinorCategory(memberId, minorCategory);
+        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK,
+                IngredientConverter.toMinorCategoryIngredientPreviewListDTO(minorCategory, ingredients));
     }
 
-    // 소분류 카테고리에 속하는 식재료 개수 조회
-    @GetMapping("/category/count")
-    @Operation(summary = "식재료 카테고리 개수 조회 API", description = "식재료 카테고리의 개수를 조회하는 API 입니다. 소분류 카테고리별 식재료 개수를 반환합니다.")
-    public ApiResponse<?> countIngredientByCategory(){
-        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, null);
-    }
 
+//    // 소분류 카테고리에 속하는 식재료 개수 조회
+//    @GetMapping("/category/count")
+//    @Operation(summary = "식재료 카테고리 개수 조회 API", description = "식재료 카테고리의 개수를 조회하는 API 입니다. 소분류 카테고리별 식재료 개수를 반환합니다.")
+//    public ApiResponse<?> countIngredientByCategory(){
+//        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, null);
+//    }
 
 
 //    // 새로운 식재료 카테고리 추가

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class IngredientResponseDTO {
 
@@ -35,6 +36,25 @@ public class IngredientResponseDTO {
         LocalDateTime updatedAt;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class IngredientDetailDTO {
+        Long memberId;
+        Long fridgeId;
+        Long ingredientId;
+        String ingredientName;
+        Long count;
+        LocalDate purchaseDate;
+        LocalDate expiryDate;
+        String storageType;
+        String majorCategory;
+        String minorCategory;
+        String ingredientImageUrl;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+    }
 
     @Getter
     @Builder
@@ -86,6 +106,18 @@ public class IngredientResponseDTO {
         private String majorCategory;
         private String minorCategory;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MinorCategoryIngredientPreviewListDTO {
+        private String minorCategory;
+        private int count;
+        private List<IngredientDetailDTO> ingredients;
+    }
+
 
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #87
## 📝작업 내용
> - 소분류 카테고리에 속하는 식재료 리스트 조회 API 구현
> - 소분류 카테고리에 해당하는 사용자의 식재료 개수도 함께 반환 (count로 반환)
<img width="80%" alt="스크린샷 2025-01-25 오후 11 59 27" src="https://github.com/user-attachments/assets/a0caa560-009a-408f-8c84-26260d765059" />
<img width="80%" alt="스크린샷 2025-01-26 오전 12 02 40" src="https://github.com/user-attachments/assets/3b297efa-c064-4e91-8f6a-22cb2931ced6" />


## 🔎코드 설명 및 참고 사항
> 

## 💬리뷰 요구사항
>
