### PR TITLE
Feat: 영수증 인식된 식재료 이름 수정 및 구매 수량 변경 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/backend/DuruDuru/global/apiPayload/code/status/SuccessStatus.java
@@ -33,7 +33,6 @@ public enum SuccessStatus implements BaseCode {
     // 채팅 관련 응답
     CHAT_OK(HttpStatus.OK, "CHAT_7000", "성공입니다.");
 
-
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                                 // Fridge 관련 접근
                                 .requestMatchers("/fridge/{member_id}/all-ingredients", "/fridge/{member_id}/near-expiry").permitAll()
                                 // OCR 관련 접근
-                                .requestMatchers("/OCR/receipt").permitAll()
+                                .requestMatchers("/OCR/receipt", "/OCR/receipt/{ingredient_id}").permitAll()
                                 // Town 관련 접근
                                 .requestMatchers("/town").permitAll()
                                 // 기타 관련 접근

--- a/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                                 // Fridge 관련 접근
                                 .requestMatchers("/fridge/{member_id}/all-ingredients", "/fridge/{member_id}/near-expiry").permitAll()
                                 // OCR 관련 접근
-                                .requestMatchers("/OCR/receipt", "/OCR/receipt/{ingredient_id}").permitAll()
+                                .requestMatchers("/OCR/receipt", "/OCR/ingredient/{ingredient_id}", "/OCR/{receipt_id/purchase-date").permitAll()
                                 // Town 관련 접근
                                 .requestMatchers("/town").permitAll()
                                 // 기타 관련 접근

--- a/src/main/java/com/backend/DuruDuru/global/converter/IngredientConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/IngredientConverter.java
@@ -129,9 +129,11 @@ public class IngredientConverter {
     public static IngredientResponseDTO.CreateOCRIngredientResultDTO toCreateOCRResultDTO(Ingredient ingredient) {
         return IngredientResponseDTO.CreateOCRIngredientResultDTO.builder()
                 .memberId(ingredient.getMember().getMemberId())
+                .receiptId(ingredient.getReceipt().getReceiptId())
                 .fridgeId(ingredient.getFridge().getFridgeId())
                 .ingredientId(ingredient.getIngredientId())
                 .ingredientName(ingredient.getIngredientName())
+                .count(ingredient.getCount())
                 .majorCategory(ingredient.getMajorCategory().name())
                 .minorCategory(ingredient.getMinorCategory().name())
                 .build();
@@ -147,6 +149,19 @@ public class IngredientConverter {
         return IngredientResponseDTO.IngredientOCRDetailListDTO.builder()
                 .purchaseDate(purchaseDate)
                 .ingredients(ingredientOCRDetailDTOList)
+                .build();
+    }
+
+    public static IngredientResponseDTO.UpdateOCRIngredientResultDTO UpdateOCRIngredientResultDTO(Ingredient ingredient) {
+        return IngredientResponseDTO.UpdateOCRIngredientResultDTO.builder()
+                .memberId(ingredient.getMember().getMemberId())
+                .receiptId(ingredient.getReceipt().getReceiptId())
+                .fridgeId(ingredient.getFridge().getFridgeId())
+                .ingredientId(ingredient.getIngredientId())
+                .ingredientName(ingredient.getIngredientName())
+                .count(ingredient.getCount())
+                .majorCategory(ingredient.getMajorCategory().name())
+                .minorCategory(ingredient.getMinorCategory().name())
                 .build();
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Ingredient.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Ingredient.java
@@ -67,6 +67,10 @@ public class Ingredient extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receipt_id", nullable = true)
+    private Receipt receipt;
+
     @OneToOne(mappedBy = "ingredient", cascade = CascadeType.ALL, orphanRemoval = true)
     private IngredientImg ingredientImg;
 
@@ -80,9 +84,19 @@ public class Ingredient extends BaseEntity {
     public void setFridge(Fridge fridge) {
         this.fridge = fridge;
     }
+
     public void update(IngredientRequestDTO.UpdateIngredientDTO request){
         this.ingredientName = request.getIngredientName();
         this.count = request.getCount();
+    }
+
+    public void updateOCR(IngredientRequestDTO.UpdateOCRIngredientDTO request){
+        this.ingredientName = request.getIngredientName();
+        this.count = request.getCount();
+    }
+
+    public void setReceipt(Receipt receipt) {
+        this.receipt = receipt;
     }
 
     public void updateCategory(MajorCategory majorCategory, MinorCategory minorCategory) {

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Member.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Member.java
@@ -70,6 +70,17 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<LikeTrade> likeTrades = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Receipt> receipts = new ArrayList<>();
+
+    public void addReceipt(Receipt receipt) {
+        this.receipts.add(receipt);
+        if (receipt.getMember() != this) {
+            receipt.setMember(this);
+        }
+    }
+
+
     public void updateToken(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Receipt.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Receipt.java
@@ -1,0 +1,31 @@
+package com.backend.DuruDuru.global.domain.entity;
+
+import com.backend.DuruDuru.global.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Receipt extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "receipt_id", nullable = false, columnDefinition = "bigint")
+    private Long receiptId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @OneToMany(mappedBy = "receipt", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Ingredient> ingredients = new ArrayList<>();
+
+}

--- a/src/main/java/com/backend/DuruDuru/global/repository/ReceiptRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/ReceiptRepository.java
@@ -1,0 +1,7 @@
+package com.backend.DuruDuru.global.repository;
+
+import com.backend.DuruDuru.global.domain.entity.Receipt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
+}

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/OCRController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/OCRController.java
@@ -5,6 +5,7 @@ import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
 import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.service.OCRService.ClovaOCRReceiptService;
+import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,8 +45,15 @@ public class OCRController {
     public ApiResponse<IngredientResponseDTO.IngredientOCRDetailListDTO> ingredientOcrAdd(@RequestParam Long memberId, @RequestParam("file") MultipartFile file) throws IOException {
         List<Ingredient> savedIngredients = clovaOCRReceiptService.extractAndCategorizeProductNames(file, memberId);
 
-        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toIngredientOCRDetailListDTO(savedIngredients));
+        return ApiResponse.onSuccess(SuccessStatus.OCR_OK, IngredientConverter.toIngredientOCRDetailListDTO(savedIngredients));
     }
 
+    @PatchMapping(value = "/receipt/{ingredient_id}")
+    @Operation (summary = "OCR 인식된 식재료 정보 수정 API", description = "OCR 인식된 식재료 이름 및 수량을 수정하는 API 입니다.")
+    public ApiResponse<IngredientResponseDTO.UpdateOCRIngredientResultDTO> ingredientOcrUpdate(@PathVariable("ingredient_id") Long ingredientId, @RequestParam Long memberId, Long receiptId,
+                                                                                         @RequestBody IngredientRequestDTO.UpdateOCRIngredientDTO request) {
+        Ingredient updateOCRIngredient = clovaOCRReceiptService.updateOCRIngredient(memberId, ingredientId, receiptId, request);
+        return ApiResponse.onSuccess(SuccessStatus.OCR_OK, IngredientConverter.UpdateOCRIngredientResultDTO(updateOCRIngredient));
+    }
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/OCRController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/OCRController.java
@@ -48,7 +48,7 @@ public class OCRController {
         return ApiResponse.onSuccess(SuccessStatus.OCR_OK, IngredientConverter.toIngredientOCRDetailListDTO(savedIngredients));
     }
 
-    @PatchMapping(value = "/receipt/{ingredient_id}")
+    @PatchMapping(value = "/ingredient/{ingredient_id}")
     @Operation (summary = "OCR 인식된 식재료 정보 수정 API", description = "OCR 인식된 식재료 이름 및 수량을 수정하는 API 입니다.")
     public ApiResponse<IngredientResponseDTO.UpdateOCRIngredientResultDTO> ingredientOcrUpdate(@PathVariable("ingredient_id") Long ingredientId, @RequestParam Long memberId, Long receiptId,
                                                                                          @RequestBody IngredientRequestDTO.UpdateOCRIngredientDTO request) {

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientRequestDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientRequestDTO.java
@@ -2,7 +2,9 @@ package com.backend.DuruDuru.global.web.dto.Ingredient;
 
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 import com.backend.DuruDuru.global.domain.enums.StorageType;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -65,11 +67,23 @@ public class IngredientRequestDTO {
     public static class SetCategoryRequestDTO {
         @NotBlank(message = "대분류를 입력해주세요.")
         private String majorCategory;
-
         @NotBlank(message = "소분류를 입력해주세요.")
         private String minorCategory;
     }
 
 
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateOCRIngredientDTO {
+        @NotBlank(message = "식재료 이름은 필수입니다.")
+        private String ingredientName;
+
+        @NotNull(message = "수량은 필수입니다.")
+        @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
+        private Long count;
+    }
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
@@ -136,10 +136,11 @@ public class IngredientResponseDTO {
     @NoArgsConstructor
     public static class CreateOCRIngredientResultDTO {
         private Long memberId;
+        private Long receiptId;
         private Long fridgeId;
         private Long ingredientId;
         private String ingredientName;
-        //private Long count;
+        private Long count;
         private String majorCategory;
         private String minorCategory;
     }
@@ -152,6 +153,22 @@ public class IngredientResponseDTO {
     public static class IngredientOCRDetailListDTO {
         private LocalDate purchaseDate;
         private List<CreateOCRIngredientResultDTO> ingredients;
+    }
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateOCRIngredientResultDTO {
+        Long memberId;
+        Long receiptId;
+        Long fridgeId;
+        Long ingredientId;
+        String ingredientName;
+        Long count;
+        String majorCategory;
+        String minorCategory;
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #96 

## 📝작업 내용
> 영수증 인식된 각 식재료의 이름 수정 및 구매 수량 변경 API 구현

## 🔎코드 설명 및 참고 사항
> 영수증 인식된 식재료 이름 수정 및 구매 수량 변경 API 구현

## 💬리뷰 요구사항
>
