### PR TITLE
Feat: 영수증 인식된 식재료의 보관방식 및 소비기한 자동 설정 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/converter/IngredientConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/IngredientConverter.java
@@ -137,6 +137,8 @@ public class IngredientConverter {
                 .count(ingredient.getCount())
                 .majorCategory(ingredient.getMajorCategory().name())
                 .minorCategory(ingredient.getMinorCategory().name())
+                .storageType(ingredient.getStorageType().name())
+                .expireDate(ingredient.getExpiryDate())
                 .build();
     }
 
@@ -163,6 +165,8 @@ public class IngredientConverter {
                 .count(ingredient.getCount())
                 .majorCategory(ingredient.getMajorCategory().name())
                 .minorCategory(ingredient.getMinorCategory().name())
+                .storageType(ingredient.getStorageType().name())
+                .expireDate(ingredient.getExpiryDate())
                 .build();
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/domain/enums/MinorCategory.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/enums/MinorCategory.java
@@ -5,100 +5,102 @@ import lombok.Getter;
 @Getter
 public enum MinorCategory {
     // 과일
-    사과(MajorCategory.과일),
-    배(MajorCategory.과일),
-    포도(MajorCategory.과일),
-    감(MajorCategory.과일),
-    견과류(MajorCategory.과일),
-    베리류(MajorCategory.과일),
-    감귤류(MajorCategory.과일),
-    과채류(MajorCategory.과일),
-    망고(MajorCategory.과일),
-    복숭아(MajorCategory.과일),
-    멜론(MajorCategory.과일),
-    파인애플(MajorCategory.과일),
+    사과(MajorCategory.과일, StorageType.냉장, 90),
+    배(MajorCategory.과일, StorageType.냉장, 21),
+    포도(MajorCategory.과일, StorageType.냉장, 14),
+    감(MajorCategory.과일, StorageType.냉장, 14),
+    견과류(MajorCategory.과일, StorageType.실온, 365),
+    베리류(MajorCategory.과일, StorageType.냉장, 5),
+    감귤류(MajorCategory.과일, StorageType.실온, 21),
+    과채류(MajorCategory.과일, StorageType.냉장, 5),
+    망고(MajorCategory.과일, StorageType.냉장, 3),
+    복숭아(MajorCategory.과일, StorageType.실온, 2),
+    멜론(MajorCategory.과일, StorageType.냉장, 6),
+    파인애플(MajorCategory.과일, StorageType.냉장, 5),
 
     // 육류
-    소고기(MajorCategory.육류),
-    소고기다짐육(MajorCategory.육류),
-    돼지고기(MajorCategory.육류),
-    닭고기(MajorCategory.육류),
-    가공육(MajorCategory.육류),
+    소고기(MajorCategory.육류, StorageType.냉장, 2),
+    소고기다짐육(MajorCategory.육류, StorageType.냉장, 2),
+    돼지고기(MajorCategory.육류, StorageType.냉장, 2),
+    닭고기(MajorCategory.육류, StorageType.냉장, 2),
+    가공육(MajorCategory.육류, StorageType.냉장, 5),
 
     // 수산물
-    담백한생선(MajorCategory.수산물),
-    기름진생선(MajorCategory.수산물),
-    조개류(MajorCategory.수산물),
-    두족류(MajorCategory.수산물),
-    갑각류(MajorCategory.수산물),
-    어묵(MajorCategory.수산물),
+    담백한생선(MajorCategory.수산물, StorageType.냉장, 2),
+    기름진생선(MajorCategory.수산물, StorageType.냉장, 2),
+    조개류(MajorCategory.수산물, StorageType.냉장, 2),
+    두족류(MajorCategory.수산물, StorageType.냉장, 2),
+    갑각류(MajorCategory.수산물, StorageType.냉장, 2),
+    어묵(MajorCategory.수산물, StorageType.냉장, 42),
 
     // 달걀
-    달걀(MajorCategory.달걀),
+    달걀(MajorCategory.달걀, StorageType.냉장, 35),
 
     // 유제품
-    우유(MajorCategory.유제품),
-    버터(MajorCategory.유제품),
-    요거트(MajorCategory.유제품),
-    치즈(MajorCategory.유제품),
-    아이스크림(MajorCategory.유제품),
-    크림(MajorCategory.유제품),
+    우유(MajorCategory.유제품, StorageType.냉장, 12),
+    버터(MajorCategory.유제품, StorageType.냉장, 90),
+    요거트(MajorCategory.유제품, StorageType.냉장, 20),
+    치즈(MajorCategory.유제품, StorageType.냉장, 120),
+    아이스크림(MajorCategory.유제품, StorageType.냉동, 365),
+    크림(MajorCategory.유제품, StorageType.냉장, 14),
 
     // 채소
-    잎채소(MajorCategory.채소),
-    뿌리채소(MajorCategory.채소),
-    콩류(MajorCategory.채소),
-    마늘(MajorCategory.채소),
-    대파(MajorCategory.채소),
-    양파(MajorCategory.채소),
-    숙주나물(MajorCategory.채소),
-    콩나물(MajorCategory.채소),
-    브로콜리(MajorCategory.채소),
+    잎채소(MajorCategory.채소, StorageType.냉장, 3),
+    뿌리채소(MajorCategory.채소, StorageType.냉장, 14),
+    콩류(MajorCategory.채소, StorageType.실온, 150),
+    마늘(MajorCategory.채소, StorageType.냉장, 20),
+    대파(MajorCategory.채소, StorageType.냉장, 14),
+    양파(MajorCategory.채소, StorageType.실온, 70),
+    숙주나물(MajorCategory.채소, StorageType.냉장, 4),
+    콩나물(MajorCategory.채소, StorageType.냉장, 7),
+    브로콜리(MajorCategory.채소, StorageType.냉장, 6),
 
     // 버섯
-    버섯(MajorCategory.버섯),
+    버섯(MajorCategory.버섯, StorageType.냉장, 10),
 
     // 두부
-    두부(MajorCategory.두부),
-    가공두부(MajorCategory.두부),
+    두부(MajorCategory.두부, StorageType.냉장, 20),
+    가공두부(MajorCategory.두부, StorageType.냉장, 90),
 
     // 건조식품
-    건조과일(MajorCategory.건조식품),
-    건미역(MajorCategory.건조식품),
+    건조과일(MajorCategory.건조식품, StorageType.실온, 150),
+    건미역(MajorCategory.건조식품, StorageType.실온, 365),
 
     // 가루
-    곡물가루(MajorCategory.가루),
-    고춧가루(MajorCategory.가루),
-    깨가루(MajorCategory.가루),
-    전분(MajorCategory.가루),
-    콩가루(MajorCategory.가루),
+    곡물가루(MajorCategory.가루, StorageType.실온, 330),
+    고춧가루(MajorCategory.가루, StorageType.냉장, 240),
+    깨가루(MajorCategory.가루, StorageType.냉장, 150),
+    전분(MajorCategory.가루, StorageType.실온, 365),
+    콩가루(MajorCategory.가루, StorageType.실온, 330),
 
     // 기타
-    통조림(MajorCategory.기타),
-    과자(MajorCategory.기타),
-    초콜릿(MajorCategory.기타),
-    과채음료(MajorCategory.기타),
-    탄산음료(MajorCategory.기타),
-    묵류(MajorCategory.기타),
-    장류(MajorCategory.기타),
-    밀떡(MajorCategory.기타),
-    쌀떡(MajorCategory.기타),
-    건조면류(MajorCategory.기타),
-    라면(MajorCategory.기타),
-    생면(MajorCategory.기타),
-    소스류(MajorCategory.기타),
-    조미료류(MajorCategory.기타),
-    기타(MajorCategory.기타);
-
-
+    통조림(MajorCategory.기타, StorageType.실온, 365),
+    과자(MajorCategory.기타, StorageType.실온, 45),
+    초콜릿(MajorCategory.기타, StorageType.실온, 90),
+    과채음료(MajorCategory.기타, StorageType.냉장, 20),
+    탄산음료(MajorCategory.기타, StorageType.냉장, 365),
+    묵류(MajorCategory.기타, StorageType.냉장, 16),
+    장류(MajorCategory.기타, StorageType.냉장, 270),
+    밀떡(MajorCategory.기타, StorageType.냉동, 270),
+    쌀떡(MajorCategory.기타, StorageType.냉동, 270),
+    건조면류(MajorCategory.기타, StorageType.실온, 365),
+    라면(MajorCategory.기타, StorageType.실온, 300),
+    생면(MajorCategory.기타, StorageType.냉장, 12),
+    소스류(MajorCategory.기타, StorageType.냉장, 180),
+    조미료류(MajorCategory.기타, StorageType.실온, 90),
+    기타(MajorCategory.기타, StorageType.실온, 90);
 
 
 
 
     private final MajorCategory majorCategory;
+    private final StorageType storageType;
+    private final int shelfLifeDays;
 
-    MinorCategory(MajorCategory majorCategory) {
+    MinorCategory(MajorCategory majorCategory, StorageType storageType, int shelfLifeDays) {
         this.majorCategory = majorCategory;
+        this.storageType = storageType;
+        this.shelfLifeDays = shelfLifeDays;
     }
 
     public static boolean isValidCategory(MajorCategory majorCategory, MinorCategory minorCategory) {

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.*;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
+import com.backend.DuruDuru.global.domain.enums.StorageType;
 import com.backend.DuruDuru.global.repository.*;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
 import jakarta.persistence.EntityManager;
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -159,7 +161,14 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
         Ingredient ingredient = ingredientRepository.findById(ingredientId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 식재료 ID입니다."));
 
+        int shelfLifeDays = minorCategory.getShelfLifeDays();
+        LocalDate updatedExpiryDate = ingredient.getPurchaseDate().plusDays(shelfLifeDays);
+        StorageType storageType = minorCategory.getStorageType();
+
         ingredient.updateCategory(majorCategory, minorCategory);
+        ingredient.setExpiryDate(updatedExpiryDate); // 소비기한 자동 설정
+        ingredient.setStorageType(storageType); // 보관 방식 자동 설정 (사용자 변경가능)
+
         return ingredientRepository.save(ingredient);
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/service/OCRService/ClovaOCRReceiptService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/OCRService/ClovaOCRReceiptService.java
@@ -6,6 +6,7 @@ import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.entity.Receipt;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
+import com.backend.DuruDuru.global.domain.enums.StorageType;
 import com.backend.DuruDuru.global.repository.FridgeRepository;
 import com.backend.DuruDuru.global.repository.IngredientRepository;
 import com.backend.DuruDuru.global.repository.MemberRepository;
@@ -286,15 +287,20 @@ public class ClovaOCRReceiptService {
             minorCategory = MinorCategory.기타; // 매핑 안되면 소분류 기타로 설정
         }
 
+        int shelfLifeDays = minorCategory.getShelfLifeDays();
+        StorageType storageType = minorCategory.getStorageType();
+
+
         Ingredient ingredient = Ingredient.builder()
                 .member(member)
                 .fridge(fridge)
                 .ingredientName(productName)
                 .majorCategory(majorCategory)
                 .minorCategory(minorCategory != null ? minorCategory : MinorCategory.기타)
+                .storageType(storageType)
                 .count(1L)
                 .purchaseDate(receipt.getPurchaseDate())
-                //.expiryDate(LocalDate.now().plusDays(7))
+                .expiryDate(receipt.getPurchaseDate().plusDays(shelfLifeDays))
                 .receipt(receipt)
                 .build();
         return ingredientRepository.save(ingredient);

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -108,12 +108,12 @@ public class IngredientController {
     }
 
 
-    // 식재료 소비기한 등록 (자동 계산 포함)
-    @PostMapping("/{ingredient_id}/expiry-date")
-    @Operation(summary = "식재료 소비기한 등록 API", description = "식재료의 소비기한을 등록하는 API 입니다.")
-    public ApiResponse<?> ingredientExpiryDate(){
-        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, null);
-    }
+//    // 식재료 소비기한 등록 (자동 계산 포함)
+//    @PostMapping("/{ingredient_id}/expiry-date")
+//    @Operation(summary = "식재료 소비기한 등록 API", description = "식재료의 소비기한을 등록하는 API 입니다.")
+//    public ApiResponse<?> ingredientExpiryDate(){
+//        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, null);
+//    }
 
 
     // 식재료 직접 등록

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
@@ -143,6 +143,8 @@ public class IngredientResponseDTO {
         private Long count;
         private String majorCategory;
         private String minorCategory;
+        private String storageType;
+        private LocalDate expireDate;
     }
 
     @Getter
@@ -161,14 +163,16 @@ public class IngredientResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateOCRIngredientResultDTO {
-        Long memberId;
-        Long receiptId;
-        Long fridgeId;
-        Long ingredientId;
-        String ingredientName;
-        Long count;
-        String majorCategory;
-        String minorCategory;
+        private Long memberId;
+        private Long receiptId;
+        private Long fridgeId;
+        private Long ingredientId;
+        private String ingredientName;
+        private Long count;
+        private String majorCategory;
+        private String minorCategory;
+        private String storageType;
+        private LocalDate expireDate;
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #95

## 📝작업 내용
> - 소분류별 대분류, 보관방식, 소비기간 매핑
> - 영수증 인식된 식재료의 소분류 카테고리에 따라 보관 방식 자동 등록 구현
> - 소분류 카테고리의 정해진 소비 기간에 따른 식재료 소비 기한 자동 계산 기능 구현
> - 식재료 직접 등록 후 카테고리 지정시, 소분류 카테고리에 따라 보관 방식 및 소비 기한 자동 계산 구현
<img width="50%" alt="스크린샷 2025-01-31 오전 1 49 01" src="https://github.com/user-attachments/assets/f63b2482-96a3-456f-93db-5fdceaa2d0fa" />
<img width="50%" alt="스크린샷 2025-01-31 오전 2 05 33" src="https://github.com/user-attachments/assets/8c66f9d2-afd9-4027-92a8-5a1f21deae51" />


## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
