### PR TITLE
Feat: Trade 엔티티에 위치 관련 칼럼 추가 및 관련 API 수정

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
@@ -18,6 +18,7 @@ public class TradeConverter {
                 .expiryDate(trade.getIngredient().getExpiryDate())
                 .title(trade.getTitle())
                 .body(trade.getBody())
+                .eupmyeondong(trade.getEupmyeondong())
                 .status(trade.getStatus())
                 .tradeType(trade.getTradeType())
                 //.tradeImgUrls(trade.getTradeImgs())
@@ -31,13 +32,20 @@ public class TradeConverter {
         if(request.getIngredientCount() > ingredient.getCount()) {
             throw new IllegalArgumentException("요청한 식재료의 개수가 현재 재고보다 많습니다.");
         }
+        // Member에 Town 정보가 없을 경우
+        if(member.getTown() == null) {
+            throw new IllegalArgumentException("Member가 Town 정보를 가지고 있지 않습니다.");
+        }
 
         return Trade.builder()
                 .member(member)
                 .ingredient(ingredient)
-                .title(request.getTitle())
-                .body(request.getBody())
                 .ingredientCount(request.getIngredientCount())
+                .title(ingredient.getIngredientName())      // 식재료 이름으로 제목 자동 설정
+                .body(request.getBody())
+                .latitude(member.getTown().getLatitude())
+                .longitude(member.getTown().getLongitude())
+                .eupmyeondong(member.getTown().getEupmyeondong())       // 읍면동 정보 저장
                 .status(Status.ACTIVE)
                 .tradeType(request.getTradeType())
                 //.tradeImgs(request.)

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Trade.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Trade.java
@@ -39,6 +39,15 @@ public class Trade extends BaseEntity {
     @Column(name = "trade_type", nullable = false, columnDefinition = "varchar(50)")
     private TradeType tradeType;
 
+    @Column(name = "latitude", nullable = false, columnDefinition = "double precision")
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false, columnDefinition = "double precision")
+    private Double longitude;
+
+    @Column(name = "eupmyeondong", nullable = false, columnDefinition = "varchar(50)")
+    private String eupmyeondong;
+
     @OneToMany(mappedBy = "trade", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChattingRoom> chattingRooms = new ArrayList<>();
 

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
@@ -4,11 +4,8 @@ import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
 
 public interface TradeCommandService {
-
     // Trade 엔티티를 저장하는 메서드
     Trade createTrade(Long memberId, Long ingredientId, TradeRequestDTO.CreateTradeRequestDTO request);
-    // 품앗이 게시글 상세 조회
-    Trade getTrade(Long tradeId);
     // 품앗이 게시글 수정
     Trade updateTrade(Long memberId, Long tradeId, TradeRequestDTO.UpdateTradeRequestDTO request);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -47,13 +47,6 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         return tradeRepository.save(newTrade);
     }
 
-    // 품앗이 게시글 상세 조회
-    @Override
-    @Transactional
-    public Trade getTrade(Long tradeId) {
-        return findTradeById(tradeId);
-    }
-
     @Override
     @Transactional
     public Trade updateTrade(Long memberId, Long tradeId, TradeRequestDTO.UpdateTradeRequestDTO request) {

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -42,6 +42,10 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
 
+        if(!member.getIngredients().contains(ingredient)) {
+            throw new IllegalArgumentException("사용자가 접근할 수 있는 식재료가 아닙니다.");
+        }
+
         Trade newTrade = TradeConverter.toCreateTrade(request, member, ingredient);
         member.addTrades(newTrade);
         return tradeRepository.save(newTrade);

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
@@ -1,7 +1,11 @@
 package com.backend.DuruDuru.global.service.TradeService;
 
 import com.backend.DuruDuru.global.domain.entity.Trade;
+import com.backend.DuruDuru.global.domain.enums.TradeType;
 
 public interface TradeQueryService {
-
+    // 품앗이 게시글 상세 조회
+    Trade getTrade(Long tradeId);
+    // 나눔, 조회별 게시글 조회
+    Trade[] getTradesByType(Long memberId, TradeType tradeType);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
@@ -1,10 +1,36 @@
 package com.backend.DuruDuru.global.service.TradeService;
 
+import com.backend.DuruDuru.global.domain.entity.Trade;
+import com.backend.DuruDuru.global.domain.enums.TradeType;
+import com.backend.DuruDuru.global.repository.MemberRepository;
+import com.backend.DuruDuru.global.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TradeQueryServiceImpl implements TradeQueryService {
+
+    private final TradeRepository tradeRepository;
+    private final MemberRepository memberRepository;
+
+    private Trade findTradeById(Long tradeId) {
+        return tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new IllegalArgumentException("Trade not found. ID: " + tradeId));
+    }
+
+    // 품앗이 게시글 상세 조회
+    @Override
+    @Transactional
+    public Trade getTrade(Long tradeId) {
+        return findTradeById(tradeId);
+    }
+
+    @Override
+    @Transactional
+    public Trade[] getTradesByType(Long memberId, TradeType tradeType) {
+        return new Trade[0];
+    }
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.backend.DuruDuru.global.service.TradeService;
 
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.enums.TradeType;
 import com.backend.DuruDuru.global.repository.MemberRepository;
@@ -20,6 +21,11 @@ public class TradeQueryServiceImpl implements TradeQueryService {
                 .orElseThrow(() -> new IllegalArgumentException("Trade not found. ID: " + tradeId));
     }
 
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found. ID: " + memberId));
+    }
+
     // 품앗이 게시글 상세 조회
     @Override
     @Transactional
@@ -30,7 +36,29 @@ public class TradeQueryServiceImpl implements TradeQueryService {
     @Override
     @Transactional
     public Trade[] getTradesByType(Long memberId, TradeType tradeType) {
+        Member member = findMemberById(memberId);
         return new Trade[0];
+    }
+
+    // 두 좌표 사이의 거리를 구하는 함수
+    // dsitance(첫번쨰 좌표의 위도, 첫번째 좌표의 경도, 두번째 좌표의 위도, 두번째 좌표의 경도)
+    private static double distance(double lat1, double lon1, double lat2, double lon2){
+        double theta = lon1 - lon2;
+        double dist = Math.sin(deg2rad(lat1))* Math.sin(deg2rad(lat2)) + Math.cos(deg2rad(lat1))*Math.cos(deg2rad(lat2))*Math.cos(deg2rad(theta));
+        dist = Math.acos(dist);
+        dist = rad2deg(dist);
+        dist = dist * 60*1.1515*1609.344;
+
+        return dist; //단위 meter
+    }
+
+    //10진수를 radian(라디안)으로 변환
+    private static double deg2rad(double deg){
+        return (deg * Math.PI/180.0);
+    }
+    //radian(라디안)을 10진수로 변환
+    private static double rad2deg(double rad){
+        return (rad * 180 / Math.PI);
     }
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -80,7 +80,7 @@ public class TradeController {
 
     // 내 근처 품앗이 나눔/교환별 조회
     @GetMapping("/near")
-    @Operation(summary = "내 근처 품앗이 나눔/교환별 조회 API", description = "나눔/교환별로 내 근처 품앗이 목록을 조회하는 API 입니다.")
+    @Operation(summary = "내 근처 품앗이 나눔/교환별 조회 API", description = "내 근처 품앗이 목록을 나눔/교환별로 조회하는 API 입니다.")
     public ApiResponse<?> findNearTradeByType(
             @RequestParam Long memberId, TradeType tradeType
     ){

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -5,6 +5,7 @@ import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
 import com.backend.DuruDuru.global.converter.TradeConverter;
 import com.backend.DuruDuru.global.domain.entity.Trade;
+import com.backend.DuruDuru.global.domain.enums.TradeType;
 import com.backend.DuruDuru.global.repository.TradeRepository;
 import com.backend.DuruDuru.global.service.TradeService.TradeCommandService;
 import com.backend.DuruDuru.global.service.TradeService.TradeQueryService;
@@ -36,7 +37,7 @@ public class TradeController {
     public ApiResponse<TradeResponseDTO.TradeDetailResultDTO> createTrade(
             @RequestParam Long memberId, Long ingredientId,
             @RequestBody TradeRequestDTO.CreateTradeRequestDTO request
-            ){
+    ){
         Trade trade = tradeCommandService.createTrade(memberId, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradeResultDTO(trade));
     }
@@ -47,7 +48,7 @@ public class TradeController {
     public ApiResponse<TradeResponseDTO.TradeDetailResultDTO> findTradeById(
             @PathVariable("trade_id") Long tradeId
     ){
-        Trade trade = tradeCommandService.getTrade(tradeId);
+        Trade trade = tradeQueryService.getTrade(tradeId);
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradeResultDTO(trade));
     }
 
@@ -55,6 +56,7 @@ public class TradeController {
     @DeleteMapping("/{trade_id}")
     @Operation(summary = "품앗이 게시글 삭제 API", description = "특정 품앗이를 삭제하는 API 입니다.")
     public ApiResponse<?> deleteTrade(){
+
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
     }
 
@@ -79,7 +81,10 @@ public class TradeController {
     // 내 근처 품앗이 나눔/교환별 조회
     @GetMapping("/near")
     @Operation(summary = "내 근처 품앗이 나눔/교환별 조회 API", description = "나눔/교환별로 내 근처 품앗이 목록을 조회하는 API 입니다.")
-    public ApiResponse<?> findNearTradeByType(){
+    public ApiResponse<?> findNearTradeByType(
+            @RequestParam Long memberId, TradeType tradeType
+    ){
+        Trade[] trades = tradeQueryService.getTradesByType(memberId, tradeType);
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeRequestDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeRequestDTO.java
@@ -10,7 +10,6 @@ public class TradeRequestDTO {
     @Getter
     public static class CreateTradeRequestDTO {
         Long ingredientCount;
-        String title;
         String body;
         TradeType tradeType;
         // TradeImg[] tradeImg;
@@ -19,7 +18,6 @@ public class TradeRequestDTO {
     @Getter
     public static class UpdateTradeRequestDTO {
         Long ingredientCount;
-        String title;
         String body;
         Status status;
         TradeType tradeType;

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
@@ -24,6 +24,7 @@ public class TradeResponseDTO {
         LocalDate expiryDate;
         String title;
         String body;
+        String eupmyeondong;
         Status status;
         TradeType tradeType;
         LocalDateTime createdAt;
@@ -43,6 +44,7 @@ public class TradeResponseDTO {
         LocalDate expiryDate;
         String title;
         String body;
+        String eupmyeondong;
         Status status;
         TradeType tradeType;
         LocalDateTime createdAt;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #122 

## 📝작업 내용
> - Trade에 위치 관련 칼럼(위도, 경도, 읍면동) 추가
> - 품앗이 게시글 등록, 조회 API에 위치 관련 response값 추가

## 🔎코드 설명 및 참고 사항
> 근처 게시글 목록을 조회할 때의 성능을 위해 Trade에 위치 관련 칼럼을 추가하였습니다.

## 💬리뷰 요구사항
> 품앗이 게시글 등록 성공
<img width="480" alt="스크린샷 2025-02-04 오전 1 05 17" src="https://github.com/user-attachments/assets/79fd8e59-a232-471e-a726-af465ac14ebc" />
