### PR TITLE
Feat: 내 근처 품앗이 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
@@ -6,6 +6,10 @@ import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.enums.Status;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeResponseDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class TradeConverter {
 
@@ -13,6 +17,7 @@ public class TradeConverter {
         return TradeResponseDTO.TradeDetailResultDTO.builder()
                 .tradeId(trade.getTradeId())
                 .memberId(trade.getMember().getMemberId())
+                .nickName(trade.getMember().getNickName())
                 .ingredientId(trade.getIngredient().getIngredientId())
                 .ingredientCount(trade.getIngredientCount())
                 .expiryDate(trade.getIngredient().getExpiryDate())
@@ -49,6 +54,36 @@ public class TradeConverter {
                 .status(Status.ACTIVE)
                 .tradeType(request.getTradeType())
                 //.tradeImgs(request.)
+                .build();
+    }
+
+    public static TradeResponseDTO.TradePreviewDTO tradePreviewDTO(Trade trade) {
+        return TradeResponseDTO.TradePreviewDTO.builder()
+                .tradeId(trade.getTradeId())
+                .memberId(trade.getMember().getMemberId())
+                .ingredientId(trade.getIngredient().getIngredientId())
+                .ingredientCount(trade.getIngredientCount())
+                .expiryDate(trade.getIngredient().getExpiryDate())
+                .title(trade.getTitle())
+                .eupmyeondong(trade.getEupmyeondong())
+                .status(trade.getStatus())
+                .tradeType(trade.getTradeType())
+                .createdAt(trade.getCreatedAt())
+                .updatedAt(trade.getUpdatedAt())
+                .build();
+    }
+
+    public static TradeResponseDTO.TradePreviewListDTO toTradePreviewListDTO(Page<Trade> tradeList) {
+        List<TradeResponseDTO.TradePreviewDTO> tradePreViewDTOList = tradeList.stream()
+                .map(TradeConverter::tradePreviewDTO).collect(Collectors.toList());
+
+        return TradeResponseDTO.TradePreviewListDTO.builder()
+                .isLast(tradeList.isLast())
+                .isFirst(tradeList.isFirst())
+                .totalPage(tradeList.getTotalPages())
+                .totalElements(tradeList.getTotalElements())
+                .listSize(tradePreViewDTOList.size())
+                .tradeList(tradePreViewDTOList)
                 .build();
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
@@ -1,7 +1,28 @@
 package com.backend.DuruDuru.global.repository;
 
 import com.backend.DuruDuru.global.domain.entity.Trade;
+import com.backend.DuruDuru.global.domain.enums.TradeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
+    // 사용자와의 거리가 1km 이내인 게시글 리스트 반환
+    @Query(value = """
+        SELECT * FROM trade
+        WHERE (6371 * acos(cos(radians(:memberLat)) * cos(radians(latitude)) * cos(radians(longitude) - radians(:memberLon)) + sin(radians(:memberLat)) * sin(radians(latitude)))) <= 1
+        AND trade_type = :tradeType
+        ORDER BY updated_at DESC
+        LIMIT :size OFFSET :offset
+        """, nativeQuery = true)
+    List<Trade> findNearbyTrades(
+            @Param("memberLat") double memberLat,
+            @Param("memberLon") double memberLon,
+            @Param("tradeType") String tradeType,
+            @Param("size") int size,
+            @Param("offset") int offset
+    );
 }
+

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
@@ -2,10 +2,13 @@ package com.backend.DuruDuru.global.service.TradeService;
 
 import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.enums.TradeType;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 public interface TradeQueryService {
     // 품앗이 게시글 상세 조회
     Trade getTrade(Long tradeId);
     // 나눔, 조회별 게시글 조회
-    Trade[] getTradesByType(Long memberId, TradeType tradeType);
+    Page<Trade> getNearTradesByType(Long memberId, TradeType tradeType, Integer page, Integer size);
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -12,11 +12,16 @@ import com.backend.DuruDuru.global.service.TradeService.TradeQueryService;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -80,12 +85,15 @@ public class TradeController {
 
     // 내 근처 품앗이 나눔/교환별 조회
     @GetMapping("/near")
-    @Operation(summary = "내 근처 품앗이 나눔/교환별 조회 API", description = "내 근처 품앗이 목록을 나눔/교환별로 조회하는 API 입니다.")
-    public ApiResponse<?> findNearTradeByType(
-            @RequestParam Long memberId, TradeType tradeType
+    @Operation(summary = "내 근처 품앗이 나눔/교환별 조회 API", description = "내 근처 품앗이 목록을 나눔/교환별로 조회하는 API 입니다. 페이징을 포함하며 query String 으로 page 번호를 주세요")
+    public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findNearTradeByType(
+            @RequestParam Long memberId,
+            @RequestParam TradeType tradeType,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int size
     ){
-        Trade[] trades = tradeQueryService.getTradesByType(memberId, tradeType);
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
+        Page<Trade> tradeList = tradeQueryService.getNearTradesByType(memberId, tradeType, page, size);
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradePreviewListDTO(tradeList));
     }
 
     // 나의 품앗이 목록 조회 API
@@ -123,6 +131,4 @@ public class TradeController {
     public ApiResponse<?> tradeAlarm(){
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
     }
-
-
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class TradeResponseDTO {
 
@@ -19,6 +20,7 @@ public class TradeResponseDTO {
     public static class TradeDetailResultDTO {
         Long tradeId;
         Long memberId;
+        String nickName;
         Long ingredientId;
         Long ingredientCount;
         LocalDate expiryDate;
@@ -39,6 +41,7 @@ public class TradeResponseDTO {
     public static class UpdateTradeResultDTO {
         Long tradeId;
         Long memberId;
+        String nickName;
         Long ingredientId;
         Long ingredientCount;
         LocalDate expiryDate;
@@ -50,5 +53,37 @@ public class TradeResponseDTO {
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
         // String[] tradeImgUrls;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TradePreviewDTO {
+        Long tradeId;
+        Long memberId;
+        Long ingredientId;
+        Long ingredientCount;
+        LocalDate expiryDate;
+        String title;
+        String eupmyeondong;
+        Status status;
+        TradeType tradeType;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+        // String thumbnailImgUrl;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TradePreviewListDTO {
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+        List<TradePreviewDTO> tradeList;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #122 

## 📝작업 내용
> 내 근처 품앗이 목록 조회 API 구현

## 🔎코드 설명 및 참고 사항
> 현재 내 위치에서(Town에 저장된 정보 기준) 반경 1km 이내에서 작성된 게시글 목록을 TradeType별로 구분하여 반환합니다
<img width="615" alt="스크린샷 2025-02-04 오후 11 40 39" src="https://github.com/user-attachments/assets/420ac44c-b6a0-4c43-9241-eb98b2678366" />


## 💬리뷰 요구사항
>
