### PR TITLE
Feat: 품앗이 게시글 등록 API에 이미지 처리 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
@@ -8,12 +8,13 @@ import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeResponseDTO;
 import org.springframework.data.domain.Page;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class TradeConverter {
 
-    public static TradeResponseDTO.TradeDetailResultDTO toTradeResultDTO(Trade trade) {
+    public static TradeResponseDTO.TradeDetailResultDTO toTradeDetailDTO(Trade trade) {
         return TradeResponseDTO.TradeDetailResultDTO.builder()
                 .tradeId(trade.getTradeId())
                 .memberId(trade.getMember().getMemberId())
@@ -26,7 +27,7 @@ public class TradeConverter {
                 .eupmyeondong(trade.getEupmyeondong())
                 .status(trade.getStatus())
                 .tradeType(trade.getTradeType())
-                //.tradeImgUrls(trade.getTradeImgs())
+                .tradeImgs(trade.getTradeImgs())
                 .createdAt(trade.getCreatedAt())
                 .updatedAt(trade.getUpdatedAt())
                 .build();
@@ -53,7 +54,7 @@ public class TradeConverter {
                 .eupmyeondong(member.getTown().getEupmyeondong())       // 읍면동 정보 저장
                 .status(Status.ACTIVE)
                 .tradeType(request.getTradeType())
-                //.tradeImgs(request.)
+                .tradeImgs(new ArrayList<>())
                 .build();
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/converter/TradeImageConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/TradeImageConverter.java
@@ -1,0 +1,14 @@
+package com.backend.DuruDuru.global.converter;
+
+import com.backend.DuruDuru.global.domain.entity.Trade;
+import com.backend.DuruDuru.global.domain.entity.TradeImg;
+
+public class TradeImageConverter {
+
+    public static TradeImg toTradeImg(String tradeImgUrl, Trade trade) {
+        return TradeImg.builder()
+                .tradeImgUrl(tradeImgUrl)
+                .trade(trade)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/TradeImg.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/TradeImg.java
@@ -1,6 +1,7 @@
 package com.backend.DuruDuru.global.domain.entity;
 
 import com.backend.DuruDuru.global.domain.common.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,8 +20,9 @@ public class TradeImg {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trade_id", nullable = false)
+    @JsonIgnore
     private Trade trade;
 
-    @Column(name = "trade_img_url", nullable = false, columnDefinition = "varchar(50)")
+    @Column(name = "trade_img_url", nullable = false, columnDefinition = "varchar(200)")
     private String tradeImgUrl;
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/TradeImageRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/TradeImageRepository.java
@@ -1,0 +1,7 @@
+package com.backend.DuruDuru.global.repository;
+
+import com.backend.DuruDuru.global.domain.entity.TradeImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeImageRepository extends JpaRepository<TradeImg, Long> {
+}

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
@@ -2,10 +2,13 @@ package com.backend.DuruDuru.global.service.TradeService;
 
 import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface TradeCommandService {
     // Trade 엔티티를 저장하는 메서드
-    Trade createTrade(Long memberId, Long ingredientId, TradeRequestDTO.CreateTradeRequestDTO request);
+    Trade createTrade(Long memberId, Long ingredientId, TradeRequestDTO.CreateTradeRequestDTO request, List<MultipartFile> tradeImgs);
     // 품앗이 게시글 수정
     Trade updateTrade(Long memberId, Long tradeId, TradeRequestDTO.UpdateTradeRequestDTO request);
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -12,14 +12,13 @@ import com.backend.DuruDuru.global.service.TradeService.TradeQueryService;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -34,17 +33,21 @@ public class TradeController {
 
     private final TradeCommandService tradeCommandService;
     private final TradeQueryService tradeQueryService;
-    private final TradeRepository tradeRepository;
 
     // 품앗이 게시글 등록
-    @PostMapping("/")
+    @PostMapping(value = "/", consumes = "multipart/form-data")
     @Operation(summary = "품앗이 게시글 등록 API", description = "품앗이 게시글을 등록하는 API 입니다.")
     public ApiResponse<TradeResponseDTO.TradeDetailResultDTO> createTrade(
-            @RequestParam Long memberId, Long ingredientId,
-            @RequestBody TradeRequestDTO.CreateTradeRequestDTO request
+            @RequestParam Long memberId,
+            @RequestParam Long ingredientId,
+            @RequestParam(value = "image", required = false) List<MultipartFile> tradeImgs, // 이미지 리스트 처리
+            @RequestParam TradeType tradeType,
+            @RequestParam String body,
+            @RequestParam Long ingredientCount
     ){
-        Trade trade = tradeCommandService.createTrade(memberId, ingredientId, request);
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradeResultDTO(trade));
+        TradeRequestDTO.CreateTradeRequestDTO request = new TradeRequestDTO.CreateTradeRequestDTO(ingredientCount, body, tradeType, tradeImgs);
+        Trade trade = tradeCommandService.createTrade(memberId, ingredientId, request, tradeImgs);
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradeDetailDTO(trade));
     }
 
     // 품앗이 상세 조회
@@ -54,7 +57,7 @@ public class TradeController {
             @PathVariable("trade_id") Long tradeId
     ){
         Trade trade = tradeQueryService.getTrade(tradeId);
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradeResultDTO(trade));
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradeDetailDTO(trade));
     }
 
     // 품앗이 게시글 삭제

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Town/TownRequestDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Town/TownRequestDTO.java
@@ -1,15 +1,21 @@
 package com.backend.DuruDuru.global.web.dto.Town;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class TownRequestDTO {
 
+    @Setter
     @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class ToTownRequestDTO {
-        double latitude;
-        double longitude;
-        String sido;
-        String sigungu;
-        String eupmyeondong;
+        private double latitude;
+        private double longitude;
+        private String sido;
+        private String sigungu;
+        private String eupmyeondong;
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeRequestDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeRequestDTO.java
@@ -3,24 +3,37 @@ package com.backend.DuruDuru.global.web.dto.Trade;
 import com.backend.DuruDuru.global.domain.entity.TradeImg;
 import com.backend.DuruDuru.global.domain.enums.Status;
 import com.backend.DuruDuru.global.domain.enums.TradeType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public class TradeRequestDTO {
 
+    @Setter
     @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class CreateTradeRequestDTO {
-        Long ingredientCount;
-        String body;
-        TradeType tradeType;
-        // TradeImg[] tradeImg;
+        private Long ingredientCount;
+        private String body;
+        private TradeType tradeType;
+        private List<MultipartFile> tradeImgs;
     }
 
+    @Setter
     @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class UpdateTradeRequestDTO {
-        Long ingredientCount;
-        String body;
-        Status status;
-        TradeType tradeType;
+        private Long ingredientCount;
+        private String body;
+        private Status status;
+        private TradeType tradeType;
         // TradeImg[] tradeImg;
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
@@ -1,5 +1,6 @@
 package com.backend.DuruDuru.global.web.dto.Trade;
 
+import com.backend.DuruDuru.global.domain.entity.TradeImg;
 import com.backend.DuruDuru.global.domain.enums.Status;
 import com.backend.DuruDuru.global.domain.enums.TradeType;
 import lombok.AllArgsConstructor;
@@ -31,7 +32,7 @@ public class TradeResponseDTO {
         TradeType tradeType;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
-        // String[] tradeImgUrls;
+        List<TradeImg> tradeImgs;
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #122 

## 📝작업 내용
> 품앗이 게시글 등록 API에 이미지 처리 구현

## 🔎코드 설명 및 참고 사항
> tradeImg를 여러장 추가할 수 있도록 구현하였습니다.
<img width="853" alt="스크린샷 2025-02-05 오후 8 57 34" src="https://github.com/user-attachments/assets/8a4a79ae-b0f4-4475-998f-21d936f951f7" />


## 💬리뷰 요구사항
>
