### PR TITLE
Feat: TradePreview에 thumbnailImg 추가

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
@@ -69,6 +69,9 @@ public class TradeConverter {
                 .eupmyeondong(trade.getEupmyeondong())
                 .status(trade.getStatus())
                 .tradeType(trade.getTradeType())
+                .thumbnailImgUrl((trade.getTradeImgs() != null && !trade.getTradeImgs().isEmpty())
+                        ? trade.getTradeImgs().get(0).getTradeImgUrl()
+                        : null)      // TradeImgs의 첫 번째 이미지를 thumbnailImg로 자동 등록
                 .createdAt(trade.getCreatedAt())
                 .updatedAt(trade.getUpdatedAt())
                 .build();


### PR DESCRIPTION
## #️⃣연관된 이슈
> #122 

## 📝작업 내용
> TradePreview에 thumbnailImg 추가

## 🔎코드 설명 및 참고 사항
> 품앗이 게시글에 등록된 사진중 첫 번째 사진을 리스트 조회시 프리뷰에서 볼 수 있는 썸네일 이미지로 자동 등록되게 구현
<img width="892" alt="스크린샷 2025-02-07 오전 10 22 10" src="https://github.com/user-attachments/assets/28b87c1c-4b66-4a73-999f-b7b6abd4530e" />

## 💬리뷰 요구사항
>
