### PR TITLE
Feat: 품앗이 게시글 수정, 삭제 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
@@ -69,9 +69,9 @@ public class TradeConverter {
                 .eupmyeondong(trade.getEupmyeondong())
                 .status(trade.getStatus())
                 .tradeType(trade.getTradeType())
-                .thumbnailImgUrl((trade.getTradeImgs() != null && !trade.getTradeImgs().isEmpty())
-                        ? trade.getTradeImgs().get(0).getTradeImgUrl()
-                        : null)      // TradeImgs의 첫 번째 이미지를 thumbnailImg로 자동 등록
+                .thumbnailImgUrl(
+                        (trade.getTradeImgs() != null && !trade.getTradeImgs().isEmpty())
+                        ? trade.getTradeImgs().get(0).getTradeImgUrl() : null)      // TradeImgs의 첫 번째 이미지를 thumbnailImg로 자동 등록
                 .createdAt(trade.getCreatedAt())
                 .updatedAt(trade.getUpdatedAt())
                 .build();

--- a/src/main/java/com/backend/DuruDuru/global/repository/TradeImageRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/TradeImageRepository.java
@@ -1,7 +1,9 @@
 package com.backend.DuruDuru.global.repository;
 
+import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.entity.TradeImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TradeImageRepository extends JpaRepository<TradeImg, Long> {
+    Long trade(Trade trade);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface TradeCommandService {
     // Trade 엔티티를 저장하는 메서드
     Trade createTrade(Long memberId, Long ingredientId, TradeRequestDTO.CreateTradeRequestDTO request, List<MultipartFile> tradeImgs);
+    // 품앗이 게시글 삭제
+    void deleteTrade(Long memberId, Long tradeId);
     // 품앗이 게시글 수정
     Trade updateTrade(Long memberId, Long tradeId, TradeRequestDTO.UpdateTradeRequestDTO request);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,9 +20,9 @@ import java.util.UUID;
 public class TradeCommandServiceImpl implements TradeCommandService {
 
     private final TradeRepository tradeRepository;
+    private final TradeImageRepository tradeImageRepository;
     private final MemberRepository memberRepository;
     private final IngredientRepository ingredientRepository;
-    private final TradeImageRepository tradeImageRepository;
     private final UuidRepository uuidRepository;
     private final AmazonS3Manager s3Manager;
 
@@ -40,6 +41,18 @@ public class TradeCommandServiceImpl implements TradeCommandService {
                 .orElseThrow(() -> new IllegalArgumentException("Trade not found. ID: " + tradeId));
     }
 
+    private TradeImg findTradeImgById(Long tradeImgId) {
+        return tradeImageRepository.findById(tradeImgId)
+                .orElseThrow(() -> new IllegalArgumentException("Trade image not found. ID: " + tradeImgId));
+    }
+
+    private String getImgUrl(MultipartFile img) {
+        String uuid = UUID.randomUUID().toString();
+        Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
+
+        return s3Manager.uploadFile(s3Manager.generatePostName(savedUuid), img);
+    }
+
     // Trade 엔티티를 저장하는 메서드
     @Override
     @Transactional
@@ -48,7 +61,7 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         Ingredient ingredient = findIngredientById(ingredientId);
 
         if(!member.getIngredients().contains(ingredient)) {
-            throw new IllegalArgumentException("사용자가 접근할 수 있는 식재료가 아닙니다.");
+            throw new IllegalArgumentException("접근 권한이 없는 식재료입니다.");
         }
 
         Trade newTrade = TradeConverter.toCreateTrade(request, member, ingredient);
@@ -58,17 +71,12 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         // 이미지 업로드 처리
         if (tradeImgs != null) {
             for (MultipartFile img : tradeImgs) {
-                if (img.isEmpty()) {
-                    continue;
-                }
-                String uuid = UUID.randomUUID().toString();
-                Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
-                String tradeImgUrl = s3Manager.uploadFile(s3Manager.generatePostName(savedUuid), img);
+                if (img.isEmpty()) continue;
+
+                String tradeImgUrl = getImgUrl(img);
 
                 TradeImg newTradeImage = TradeImageConverter.toTradeImg(tradeImgUrl, newTrade);
                 tradeImageRepository.save(newTradeImage);
-
-                System.out.println("이미지 링크 받아오기 성공" + newTradeImage.getTradeImgUrl());
                 newTrade.getTradeImgs().add(newTradeImage);
             }
         }
@@ -77,6 +85,7 @@ public class TradeCommandServiceImpl implements TradeCommandService {
 
     // 품앗이 게시글 삭제
     @Override
+    @Transactional
     public void deleteTrade(Long memberId, Long tradeId) {
         Trade trade = findTradeById(tradeId);
         Member member = findMemberById(memberId);
@@ -88,11 +97,44 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         tradeRepository.delete(trade);
     }
 
+    // 품앗이 게시글 수정
     @Override
     @Transactional
     public Trade updateTrade(Long memberId, Long tradeId, TradeRequestDTO.UpdateTradeRequestDTO request) {
-        Trade updateTrade = findTradeById(tradeId);
+        Trade trade = findTradeById(tradeId);
+        Member member = findMemberById(memberId);
 
-        return tradeRepository.save(updateTrade);
+        if(!trade.getMember().getMemberId().equals(member.getMemberId())) throw new IllegalArgumentException("접근 권한이 없는 게시글입니다.");
+
+        // 기존 이미지를 삭제한 경우
+        if (request.getDeleteImgIds() != null && !request.getDeleteImgIds().isEmpty()) {
+            for(Long imgId : request.getDeleteImgIds()) {
+                TradeImg existingTradeImg = findTradeImgById(imgId);
+
+                if (!trade.getTradeImgs().contains(existingTradeImg)) throw new IllegalArgumentException("해당 게시글에 포함된 이미지가 아닙니다. TradeImgId: " + imgId);
+
+                // DB, S3에서 삭제
+                trade.getTradeImgs().remove(existingTradeImg);
+                tradeImageRepository.delete(existingTradeImg);
+                s3Manager.deleteFile(existingTradeImg.getTradeImgUrl());
+            }
+        }
+
+        // 새로운 이미지를 추가한 경우
+        if (request.getAddTradeImgs() != null) {
+            for (MultipartFile img : request.getAddTradeImgs()) {
+                String tradeImgUrl = getImgUrl(img);
+                TradeImg newTradeImage = TradeImageConverter.toTradeImg(tradeImgUrl, trade);
+                tradeImageRepository.save(newTradeImage);
+            }
+        }
+
+        // 기타 request 처리
+        if (request.getIngredientCount() != null) trade.setIngredientCount(request.getIngredientCount());
+        if (request.getBody() != null) trade.setBody(request.getBody());
+        if (request.getTradeType() != null) trade.setTradeType(request.getTradeType());
+        if (request.getStatus() != null) trade.setStatus(request.getStatus());
+
+        return tradeRepository.save(trade);
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -74,6 +73,19 @@ public class TradeCommandServiceImpl implements TradeCommandService {
             }
         }
         return tradeRepository.save(newTrade);
+    }
+
+    // 품앗이 게시글 삭제
+    @Override
+    public void deleteTrade(Long memberId, Long tradeId) {
+        Trade trade = findTradeById(tradeId);
+        Member member = findMemberById(memberId);
+
+        if(!trade.getMember().getMemberId().equals(member.getMemberId())) {
+            throw new IllegalArgumentException("접근 권한이 없는 게시글입니다.");
+        }
+
+        tradeRepository.delete(trade);
     }
 
     @Override

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -5,8 +5,8 @@ import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
 import com.backend.DuruDuru.global.converter.TradeConverter;
 import com.backend.DuruDuru.global.domain.entity.Trade;
+import com.backend.DuruDuru.global.domain.enums.Status;
 import com.backend.DuruDuru.global.domain.enums.TradeType;
-import com.backend.DuruDuru.global.repository.TradeRepository;
 import com.backend.DuruDuru.global.service.TradeService.TradeCommandService;
 import com.backend.DuruDuru.global.service.TradeService.TradeQueryService;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -72,14 +71,21 @@ public class TradeController {
     }
 
     // 품앗이 게시글 수정
-    @PatchMapping("/{trade_id}")
+    @PatchMapping(value = "/{trade_id}", consumes = "multipart/form-data")
     @Operation(summary = "품앗이 게시글 수정 API", description = "특정 품앗이를 수정하는 API 입니다.")
-    public ApiResponse<TradeResponseDTO.UpdateTradeResultDTO> updateTrade(
-            @PathVariable("trade_id") Long memberId, Long tradeId,
-            @RequestBody TradeRequestDTO.UpdateTradeRequestDTO request
+    public ApiResponse<TradeResponseDTO.TradeDetailResultDTO> updateTrade(
+            @PathVariable("trade_id") Long tradeId,
+            @RequestParam Long memberId,
+            @RequestParam(required = false) List<Long> deleteImgIds,
+            @RequestParam(value = "addImgs", required = false) List<MultipartFile> addImgs, // 이미지 리스트 처리
+            @RequestParam(required = false) TradeType tradeType,
+            @RequestParam(required = false) Status status,
+            @RequestParam(required = false) String body,
+            @RequestParam(required = false) Long ingredientCount
     ){
+        TradeRequestDTO.UpdateTradeRequestDTO request = new TradeRequestDTO.UpdateTradeRequestDTO(ingredientCount, body, tradeType, status, deleteImgIds, addImgs);
         Trade trade = tradeCommandService.updateTrade(memberId, tradeId, request);
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradeDetailDTO(trade));
     }
 
     // 내 근처 품앗이 나눔/교환별 조회

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -63,8 +63,11 @@ public class TradeController {
     // 품앗이 게시글 삭제
     @DeleteMapping("/{trade_id}")
     @Operation(summary = "품앗이 게시글 삭제 API", description = "특정 품앗이를 삭제하는 API 입니다.")
-    public ApiResponse<?> deleteTrade(){
-
+    public ApiResponse<?> deleteTrade(
+            @RequestParam Long memberId,
+            @PathVariable("trade_id") Long tradeId
+    ){
+        tradeCommandService.deleteTrade(memberId, tradeId);
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeRequestDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeRequestDTO.java
@@ -32,8 +32,9 @@ public class TradeRequestDTO {
     public static class UpdateTradeRequestDTO {
         private Long ingredientCount;
         private String body;
-        private Status status;
         private TradeType tradeType;
-        // TradeImg[] tradeImg;
+        private Status status;
+        private List<Long> deleteImgIds;
+        private List<MultipartFile> addTradeImgs;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #89 

## 📝작업 내용
> 품앗이 게시글 삭제 API 구현
> 품앗이 게시글 수정 API에서 기존 이미지 삭제, 새로운 이미지 추가할 수 있도록 구현

## 🔎코드 설명 및 참고 사항
- 기존 이미지 삭제는 TradeImgId로 가능합니다
- 새로운 이미지 추가는 파일 첨부로 가능합니다

## 💬리뷰 요구사항
>
