### PR TITLE
Feat: 식재료 소비기한 임박순, 여유순으로 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                                 .requestMatchers("/ingredient/{ingredient_id}","/ingredient/{ingredient_id}/category", "/ingredient/{ingredient_id}/storage-type").permitAll()
                                 .requestMatchers("/ingredient/search/name", "/ingredient/search/category/list", "/ingredient/category/major-to-minor").permitAll()
                                 // Fridge 관련 접근
-                                .requestMatchers("/fridge/{member_id}/all/recent", "/fridge/{member_id}/near-expiry", "/fridge/{member_id}/far-expiry","/fridge/{member_id}/days-left").permitAll()
+                                .requestMatchers("/fridge/{member_id}/all/recent", "/fridge/{member_id}/near-expiry", "/fridge/{member_id}/far-expiry").permitAll()
                                 // OCR 관련 접근
                                 .requestMatchers("/OCR/receipt", "/OCR/ingredient/{ingredient_id}", "/OCR/{receipt_id}/purchase-date").permitAll()
                                 // Town 관련 접근

--- a/src/main/java/com/backend/DuruDuru/global/converter/FridgeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/FridgeConverter.java
@@ -1,0 +1,40 @@
+package com.backend.DuruDuru.global.converter;
+
+import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.web.dto.Fridge.FridgeResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FridgeConverter {
+
+    public static FridgeResponseDTO.IngredientDetailDTO toIngredientDetailDTO(Ingredient ingredient) {
+        return FridgeResponseDTO.IngredientDetailDTO.builder()
+                .memberId(ingredient.getMember().getMemberId())
+                .fridgeId(ingredient.getFridge().getFridgeId())
+                .ingredientId(ingredient.getIngredientId())
+                .ingredientName(ingredient.getIngredientName())
+                .count(ingredient.getCount())
+                .purchaseDate(ingredient.getPurchaseDate())
+                .expiryDate(ingredient.getExpiryDate())
+                .storageType(String.valueOf(ingredient.getStorageType()))
+                .majorCategory(ingredient.getMajorCategory().name())
+                .minorCategory(ingredient.getMinorCategory().name())
+                .ingredientImageUrl(ingredient.getIngredientImg() != null ?
+                        ingredient.getIngredientImg().getIngredientImgUrl() : "https://duruduru.s3.ap-northeast-2.amazonaws.com/76636494-cfa7-4b1b-8649-2eda45f1be8a")
+                .createdAt(ingredient.getCreatedAt())
+                .updatedAt(ingredient.getUpdatedAt())
+                .build();
+    }
+
+    public static FridgeResponseDTO.IngredientDetailListDTO toIngredientDetailListDTO(List<Ingredient> ingredients) {
+        List<FridgeResponseDTO.IngredientDetailDTO> ingredientDetailDTOList = ingredients.stream()
+                .map(FridgeConverter::toIngredientDetailDTO)
+                .collect(Collectors.toList());
+
+        return FridgeResponseDTO.IngredientDetailListDTO.builder()
+                .ingredients(ingredientDetailDTOList)
+                .count(ingredients.size())
+                .build();
+    }
+}

--- a/src/main/java/com/backend/DuruDuru/global/converter/FridgeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/FridgeConverter.java
@@ -3,6 +3,8 @@ package com.backend.DuruDuru.global.converter;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.web.dto.Fridge.FridgeResponseDTO;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +19,7 @@ public class FridgeConverter {
                 .count(ingredient.getCount())
                 .purchaseDate(ingredient.getPurchaseDate())
                 .expiryDate(ingredient.getExpiryDate())
+                .dDay(ingredient.getDDay())
                 .storageType(String.valueOf(ingredient.getStorageType()))
                 .majorCategory(ingredient.getMajorCategory().name())
                 .minorCategory(ingredient.getMinorCategory().name())

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Ingredient.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Ingredient.java
@@ -10,6 +10,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,6 +38,9 @@ public class Ingredient extends BaseEntity {
 
     @Column(name = "expiry_date", nullable = true, columnDefinition = "timestamp")
     private LocalDate expiryDate;
+
+    @Column(name = "d_day", nullable = false, columnDefinition = "bigint")
+    private Long dDay;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "storage_type", nullable = true, columnDefinition = "varchar(50)")
@@ -102,10 +106,24 @@ public class Ingredient extends BaseEntity {
     public void updateCategory(MajorCategory majorCategory, MinorCategory minorCategory) {
         this.majorCategory = majorCategory;
         this.minorCategory = minorCategory;
+        calculateDDay(); // 카테고리 변경시 D-Day 다시 계산
     }
 
     public void setIngredientImg(IngredientImg ingredientImg) {
         this.ingredientImg = ingredientImg;
         ingredientImg.setIngredient(this);
     }
+
+    public void calculateDDay() {
+        LocalDate today = LocalDate.now();
+        this.dDay = (this.expiryDate != null) ? ChronoUnit.DAYS.between(today, this.expiryDate) : Long.MAX_VALUE;
+    }
+
+    @PrePersist
+    @PreUpdate
+    public void updateDDay() {
+        calculateDDay();
+    }
+
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -15,5 +15,6 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     // 냉장고 관련 메서드
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(Long memberId);
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByExpiryDateAsc(Long memberId);
+    List<Ingredient> findAllByFridge_Member_MemberIdOrderByExpiryDateDesc(Long memberId);
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -11,6 +11,9 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     List<Ingredient> findByMember_MemberIdAndMinorCategory(Long memberId, MinorCategory minorCategory);
     List<Ingredient> findAllByIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(String search);
     List<Ingredient> findAllByOrderByCreatedAtDesc();
+
+    // 냉장고 관련 메서드
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(Long memberId);
+    List<Ingredient> findAllByFridge_Member_MemberIdOrderByExpiryDateAsc(Long memberId);
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -3,6 +3,8 @@ package com.backend.DuruDuru.global.repository;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,7 +16,12 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
     // 냉장고 관련 메서드
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(Long memberId);
-    List<Ingredient> findAllByFridge_Member_MemberIdOrderByExpiryDateAsc(Long memberId);
-    List<Ingredient> findAllByFridge_Member_MemberIdOrderByExpiryDateDesc(Long memberId);
+//    List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayAsc(Long memberId);
+//    List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayDesc(Long memberId);
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay ASC")
+    List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayAsc(@Param("memberId") Long memberId);
+
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay DESC")
+    List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayDesc(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 public interface FridgeQueryService {
 
-    List<Ingredient> getIngredients(Long memberId);
+    List<Ingredient> getAllIngredients(Long memberId);
+    List<Ingredient> getIngredientsNearExpiry(Long memberId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
@@ -8,4 +8,5 @@ public interface FridgeQueryService {
 
     List<Ingredient> getAllIngredients(Long memberId);
     List<Ingredient> getIngredientsNearExpiry(Long memberId);
+    List<Ingredient> getIngredientsFarExpiry(Long memberId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -31,9 +31,15 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     }
 
     @Override
-    public List<Ingredient> getIngredients(Long memberId) {
+    public List<Ingredient> getAllIngredients(Long memberId) {
         findMemberById(memberId);
         return ingredientRepository.findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(memberId);
+    }
+
+    @Override
+    public List<Ingredient> getIngredientsNearExpiry(Long memberId) {
+        findMemberById(memberId);
+        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByExpiryDateAsc(memberId);
     }
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -1,6 +1,5 @@
 package com.backend.DuruDuru.global.service.FridgeService;
 
-
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.repository.FridgeRepository;
@@ -12,7 +11,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,13 +41,13 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     @Override
     public List<Ingredient> getIngredientsNearExpiry(Long memberId) {
         findMemberById(memberId);
-        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByExpiryDateAsc(memberId);
+        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayAsc(memberId);
     }
 
     @Override
     public List<Ingredient> getIngredientsFarExpiry(Long memberId) {
         findMemberById(memberId);
-        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByExpiryDateDesc(memberId);
+        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayDesc(memberId);
     }
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -42,4 +42,10 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
         return ingredientRepository.findAllByFridge_Member_MemberIdOrderByExpiryDateAsc(memberId);
     }
 
+    @Override
+    public List<Ingredient> getIngredientsFarExpiry(Long memberId) {
+        findMemberById(memberId);
+        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByExpiryDateDesc(memberId);
+    }
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -52,10 +52,11 @@ public class FridgeController {
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
-    // 식재료 남은 일 수 조회 (5일 이내)
-    @GetMapping("/{member_id}/days-left")
-    @Operation(summary = "식재료 남은 일 수(5일 이내) 조회 API", description = "소비기한이 5일 이내로 남은 식재료의 남은 일 수를 조회하는 API 입니다.")
-    public ApiResponse<?> ingredientLeftDays() {
-        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, null);
-    }
+//    // 식재료 남은 일 수 조회 (5일 이내)
+//    @GetMapping("/{member_id}/days-left")
+//    @Operation(summary = "식재료 남은 일 수(5일 이내) 조회 API", description = "소비기한이 5일 이내로 남은 식재료의 남은 일 수를 조회하는 API 입니다.")
+//    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientLeftDays(@PathVariable("member_id") Long memberId) {
+//        List<Ingredient> ingredients = fridgeQueryService.getIngredientsD_day(memberId);
+//        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, null);
+//    }
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -47,8 +47,9 @@ public class FridgeController {
     // 소비기한 여유순 식재료 리스트 조회
     @GetMapping("/{member_id}/far-expiry")
     @Operation(summary = "식재료 소비기한 여유순 리스트 조회 API", description = "식재료 리스트를 소비기한이 여유로운 순서대로 조회하는 API 입니다.")
-    public ApiResponse<?> ingredientFarExpiry() {
-        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, null);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientFarExpiry(@PathVariable("member_id") Long memberId) {
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsFarExpiry(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 식재료 남은 일 수 조회 (5일 이내)

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -1,8 +1,10 @@
 package com.backend.DuruDuru.global.web.controller;
 
+import com.backend.DuruDuru.global.converter.FridgeConverter;
 import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.service.FridgeService.FridgeQueryService;
+import com.backend.DuruDuru.global.web.dto.Fridge.FridgeResponseDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
 import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
@@ -29,29 +31,29 @@ public class FridgeController {
     // 전체 식재료 리스트 조회 (최신 등록순)
     @GetMapping("/{member_id}/all/recent")
     @Operation(summary = "최신 등록된 순으로 전체 식재료 리스트 조회 API", description = "사용자의 냉장고에 최신 등록된 순으로 전체 식재료 리스트를 조회하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.IngredientDetailListDTO> findAllRecentIngredients(@PathVariable("member_id") Long memberId) {
-        List<Ingredient> ingredients = fridgeQueryService.getIngredients(memberId);
-        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, IngredientConverter.toIngredientDetailListDTO(ingredients));
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentIngredients(@PathVariable("member_id") Long memberId) {
+        List<Ingredient> ingredients = fridgeQueryService.getAllIngredients(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
-
-    // 소비기한 임박 식재료 조회
+    // 소비기한 임박순 식재료 리스트 조회
     @GetMapping("/{member_id}/near-expiry")
-    @Operation(summary = "소비기한 임박 식재료 조회 API", description = "소비기한이 임박한 순서대로 식재료 리스트를 조회하는 API 입니다.")
-    public ApiResponse<?> ingredientNearExpiry() {
-        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, null);
+    @Operation(summary = "식재료 소비기한 임박순 리스트 조회 API", description = "식재료 리스트를 소비기한이 임박한 순서대로 조회하는 API 입니다.")
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientNearExpiry(@PathVariable("member_id") Long memberId) {
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsNearExpiry(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
-    // 소비기한 여유 식재료 조회
+    // 소비기한 여유순 식재료 리스트 조회
     @GetMapping("/{member_id}/far-expiry")
-    @Operation(summary = "소비기한 여유 식재료 조회 API", description = "소비기한이 여유로운 순서대로 식재료 리스트를 조회하는 API 입니다.")
+    @Operation(summary = "식재료 소비기한 여유순 리스트 조회 API", description = "식재료 리스트를 소비기한이 여유로운 순서대로 조회하는 API 입니다.")
     public ApiResponse<?> ingredientFarExpiry() {
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, null);
     }
 
-    // 식재료 남은 일 수 조회
+    // 식재료 남은 일 수 조회 (5일 이내)
     @GetMapping("/{member_id}/days-left")
-    @Operation(summary = "식재료 남은 일 수 조회 API", description = "식재료의 남은 일 수를 조회하는 API 입니다.")
+    @Operation(summary = "식재료 남은 일 수(5일 이내) 조회 API", description = "소비기한이 5일 이내로 남은 식재료의 남은 일 수를 조회하는 API 입니다.")
     public ApiResponse<?> ingredientLeftDays() {
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, null);
     }

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Fridge/FridgeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Fridge/FridgeResponseDTO.java
@@ -1,0 +1,42 @@
+package com.backend.DuruDuru.global.web.dto.Fridge;
+
+import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class FridgeResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class IngredientDetailDTO {
+        Long memberId;
+        Long fridgeId;
+        Long ingredientId;
+        String ingredientName;
+        Long count;
+        LocalDate purchaseDate;
+        LocalDate expiryDate;
+        String storageType;
+        String majorCategory;
+        String minorCategory;
+        String ingredientImageUrl;
+        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class IngredientDetailListDTO {
+        private int count;
+        private List<FridgeResponseDTO.IngredientDetailDTO> ingredients;
+    }
+
+}

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Fridge/FridgeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Fridge/FridgeResponseDTO.java
@@ -21,6 +21,7 @@ public class FridgeResponseDTO {
         Long count;
         LocalDate purchaseDate;
         LocalDate expiryDate;
+        Long dDay;
         String storageType;
         String majorCategory;
         String minorCategory;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #100

## 📝작업 내용
> - 식재료 소비기한 임박순, 여유순으로 리스트 조회 API 구현
> - Ingredient 엔티티 dDay 컬럼 추가
> - 사용자 냉장고의 식재료 조회시 dDay 계산 결과를 통해 정렬하여 반환하도록 구현
<img width="80%" alt="스크린샷 2025-02-08 오후 3 43 09" src="https://github.com/user-attachments/assets/bea66ca7-2596-4d77-ab86-3c4e09a98a61" />


## 🔎코드 설명 및 참고 사항
> - JPA 메서드 이름 기반 정렬이 오류를 일으키므로 명시적 정렬 쿼리를 작성하여 dDay 필드가 인식되도록 수정

## 💬리뷰 요구사항
>
