### PR TITLE
Refactor: 품앗이 게시글 수정 API 이미지 삭제후 추가 오류 수정

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -59,10 +59,7 @@ public class TradeCommandServiceImpl implements TradeCommandService {
     public Trade createTrade(Long memberId, Long ingredientId, TradeRequestDTO.CreateTradeRequestDTO request, List<MultipartFile> tradeImgs) {
         Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
-
-        if(!member.getIngredients().contains(ingredient)) {
-            throw new IllegalArgumentException("접근 권한이 없는 식재료입니다.");
-        }
+        if(!member.getIngredients().contains(ingredient)) throw new IllegalArgumentException("접근 권한이 없는 식재료입니다.");
 
         Trade newTrade = TradeConverter.toCreateTrade(request, member, ingredient);
         member.addTrades(newTrade);
@@ -90,9 +87,7 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         Trade trade = findTradeById(tradeId);
         Member member = findMemberById(memberId);
 
-        if(!trade.getMember().getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("접근 권한이 없는 게시글입니다.");
-        }
+        if(!trade.getMember().getMemberId().equals(member.getMemberId())) throw new IllegalArgumentException("접근 권한이 없는 게시글입니다.");
 
         tradeRepository.delete(trade);
     }
@@ -124,8 +119,10 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         if (request.getAddTradeImgs() != null) {
             for (MultipartFile img : request.getAddTradeImgs()) {
                 String tradeImgUrl = getImgUrl(img);
+
                 TradeImg newTradeImage = TradeImageConverter.toTradeImg(tradeImgUrl, trade);
                 tradeImageRepository.save(newTradeImage);
+                trade.getTradeImgs().add(newTradeImage);
             }
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #89 

## 📝작업 내용
> 품앗이 게시글 수정 API에서 기존 이미지 삭제와 새로운 이미지 추가를 동시에 진행하면 추가한 이미지가 response 값에서 보이지 않는 오류를 수정했습니다

## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
