### PR TITLE
Feat: 식재료 남은 일 수를 개월/년 단위로 반환하는 응답 추가

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/converter/FridgeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/FridgeConverter.java
@@ -20,6 +20,7 @@ public class FridgeConverter {
                 .purchaseDate(ingredient.getPurchaseDate())
                 .expiryDate(ingredient.getExpiryDate())
                 .dDay(ingredient.getDDay())
+                .dDayFormatted(ingredient.getFormattedDDay())
                 .storageType(String.valueOf(ingredient.getStorageType()))
                 .majorCategory(ingredient.getMajorCategory().name())
                 .minorCategory(ingredient.getMinorCategory().name())

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Ingredient.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Ingredient.java
@@ -4,6 +4,7 @@ import com.backend.DuruDuru.global.domain.common.BaseEntity;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 import com.backend.DuruDuru.global.domain.enums.StorageType;
+import com.backend.DuruDuru.global.service.IngredientService.DateFormatter;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
 import jakarta.persistence.*;
 import lombok.*;
@@ -124,6 +125,12 @@ public class Ingredient extends BaseEntity {
     public void updateDDay() {
         calculateDDay();
     }
+
+    @Transient
+    public String getFormattedDDay() {
+        return DateFormatter.formatRemainingDays(this.dDay);
+    }
+
 
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/domain/enums/MinorCategory.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/enums/MinorCategory.java
@@ -75,7 +75,7 @@ public enum MinorCategory {
 
     // 기타
     통조림(MajorCategory.기타, StorageType.실온, 365),
-    과자(MajorCategory.기타, StorageType.실온, 45),
+    과자(MajorCategory.기타, StorageType.실온, 90),
     초콜릿(MajorCategory.기타, StorageType.실온, 90),
     과채음료(MajorCategory.기타, StorageType.냉장, 20),
     탄산음료(MajorCategory.기타, StorageType.냉장, 365),
@@ -84,6 +84,7 @@ public enum MinorCategory {
     밀떡(MajorCategory.기타, StorageType.냉동, 270),
     쌀떡(MajorCategory.기타, StorageType.냉동, 270),
     건조면류(MajorCategory.기타, StorageType.실온, 365),
+    냉동면류(MajorCategory.기타, StorageType.냉동, 365),
     라면(MajorCategory.기타, StorageType.실온, 300),
     생면(MajorCategory.기타, StorageType.냉장, 12),
     소스류(MajorCategory.기타, StorageType.냉장, 180),

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/DateFormatter.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/DateFormatter.java
@@ -1,0 +1,38 @@
+package com.backend.DuruDuru.global.service.IngredientService;
+
+public class DateFormatter {
+
+    public static String formatRemainingDays(long dDay) {
+        if (dDay < 30) {
+            return dDay + "일";
+        } else if (dDay < 60) {
+            return "2개월";
+        } else if (dDay < 90) {
+            return "3개월";
+        } else if (dDay < 365) {
+            int months = (int) (dDay / 30);
+            return months + "개월";
+        } else {
+            int years = (int) (dDay / 365);
+            int remainingDays = (int) (dDay % 365);
+            int months = remainingDays / 30;
+            return months == 0 ? years + "년" : years + "년 " + months + "개월";
+        }
+    }
+
+    public static void main(String[] args) {
+        System.out.println(formatRemainingDays(10));   // 10일
+        System.out.println(formatRemainingDays(29));   // 29일
+        System.out.println(formatRemainingDays(30));   // 2개월
+        System.out.println(formatRemainingDays(59));   // 2개월
+        System.out.println(formatRemainingDays(60));   // 3개월
+        System.out.println(formatRemainingDays(89));   // 3개월
+        System.out.println(formatRemainingDays(90));   // 3개월
+        System.out.println(formatRemainingDays(120));  // 4개월
+        System.out.println(formatRemainingDays(365));  // 1년
+        System.out.println(formatRemainingDays(400));  // 1년 1개월
+        System.out.println(formatRemainingDays(730));  // 2년
+        System.out.println(formatRemainingDays(800));  // 2년 2개월
+    }
+}
+

--- a/src/main/java/com/backend/DuruDuru/global/service/OCRService/CategoryMapper.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/OCRService/CategoryMapper.java
@@ -220,6 +220,11 @@ public class CategoryMapper {
         keywordToMinorCategoryMap.put("동원참치", MinorCategory.통조림);
 
         keywordToMinorCategoryMap.put("과자", MinorCategory.과자);
+        keywordToMinorCategoryMap.put("땅콩샌드", MinorCategory.과자);
+        keywordToMinorCategoryMap.put("초코파이", MinorCategory.과자);
+        keywordToMinorCategoryMap.put("칩", MinorCategory.과자);
+        keywordToMinorCategoryMap.put("쿠키", MinorCategory.과자);
+
         keywordToMinorCategoryMap.put("초콜릿", MinorCategory.초콜릿);
         keywordToMinorCategoryMap.put("탄산음료", MinorCategory.탄산음료);
 
@@ -242,6 +247,7 @@ public class CategoryMapper {
         keywordToMinorCategoryMap.put("건면", MinorCategory.건조면류);
         keywordToMinorCategoryMap.put("밀면", MinorCategory.생면);
         keywordToMinorCategoryMap.put("생면", MinorCategory.생면);
+        keywordToMinorCategoryMap.put("냉동중화면", MinorCategory.냉동면류);
 
         keywordToMinorCategoryMap.put("라면", MinorCategory.라면);
         keywordToMinorCategoryMap.put("신라면", MinorCategory.라면);
@@ -257,10 +263,13 @@ public class CategoryMapper {
         keywordToMinorCategoryMap.put("마요네즈", MinorCategory.소스류);
         keywordToMinorCategoryMap.put("머스타드", MinorCategory.소스류);
         keywordToMinorCategoryMap.put("바베큐소스", MinorCategory.소스류);
+        keywordToMinorCategoryMap.put("토마토소스", MinorCategory.소스류);
+        keywordToMinorCategoryMap.put("굴소스", MinorCategory.소스류);
 
         keywordToMinorCategoryMap.put("빵", MinorCategory.기타);
         keywordToMinorCategoryMap.put("밥", MinorCategory.기타);
         keywordToMinorCategoryMap.put("햇반", MinorCategory.기타);
+        keywordToMinorCategoryMap.put("식빵", MinorCategory.기타);
 
         keywordToMinorCategoryMap.put("설탕", MinorCategory.조미료류);
         keywordToMinorCategoryMap.put("소금", MinorCategory.조미료류);

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Fridge/FridgeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Fridge/FridgeResponseDTO.java
@@ -22,6 +22,7 @@ public class FridgeResponseDTO {
         LocalDate purchaseDate;
         LocalDate expiryDate;
         Long dDay;
+        String dDayFormatted;
         String storageType;
         String majorCategory;
         String minorCategory;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #100

## 📝작업 내용
> 식재료 남은 일 수 반환시 개월, 년 단위로 반환하는 응답 추가
<img width="80%" alt="스크린샷 2025-02-08 오후 5 14 16" src="https://github.com/user-attachments/assets/aa6d276e-14a6-44a5-8844-b2f928e72007" />


## 🔎코드 설명 및 참고 사항
> - 기존에는 식재료의 남은 일 수(dDay)를 단순히 정수형 일(day) 단위로 반환
> - 식재료의 남은 일 수를 단순히 정수형으로 반환하던 것에서 1개월 이상 남은 경우 "2개월", 
"1년 6개월"의 형식으로 변환하여 응답하도록 수정
> - 변환 로직은 DateFormatter에서 formatRemainingDays 메소드를 통해 구현

## 💬리뷰 요구사항
>
