### PR TITLE
Feat: 나의 품앗이 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                                 // Member 관련 접근
                                 .requestMatchers("/member/register", "/member/login/kakao", "/member/login/email","/member/refresh").permitAll()
                                 // Trade 관련 접근
-                                .requestMatchers("/trade/", "trade/{trade_id}", "/trade/near", "/trade/shareUrl", "/trade/recommend/today", "/trade/keyword/alert", "/trade/current", "/trade/history").permitAll()
+                                .requestMatchers("/trade/", "trade/{trade_id}", "/trade/near", "/trade/shareUrl", "/trade/recommend/today", "/trade/keyword/alert", "/trade/my/active", "/trade/my/history").permitAll()
                                 // 다른 엔티티 관련 접근
                                 .requestMatchers("/example/**").permitAll()
                                 // Ingredient 관련 접근

--- a/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
@@ -2,7 +2,6 @@ package com.backend.DuruDuru.global.repository;
 
 import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.entity.Trade;
-import com.backend.DuruDuru.global.domain.enums.TradeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +9,18 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
+
+    // 사용자의 전체 게시글 반환
+    List<Trade> findAllByMemberOrderByUpdatedAtDesc(Member member);
+
+    // 사용자의 활성화된 게시글 반환
+    @Query(value = """
+        SELECT * FROM trade
+        WHERE member_id = :memberId AND (status = 'ACTIVE' OR status = 'PROCEEDING')
+        ORDER BY updated_at DESC
+        """, nativeQuery = true)
+    List<Trade> findActiveTradesByMember(@Param("memberId") Long memberId);
+
     // 사용자와의 거리가 1km 이내인 게시글 리스트 반환
     @Query(value = """
         SELECT * FROM trade
@@ -23,6 +34,5 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
             @Param("tradeType") String tradeType
     );
 
-    List<Trade> findAllByMember(Member member);
 }
 

--- a/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
@@ -1,5 +1,6 @@
 package com.backend.DuruDuru.global.repository;
 
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.enums.TradeType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,5 +22,7 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
             @Param("memberLon") double memberLon,
             @Param("tradeType") String tradeType
     );
+
+    List<Trade> findAllByMember(Member member);
 }
 

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
@@ -12,4 +12,6 @@ public interface TradeQueryService {
     List<Trade> getNearTradesByType(Long memberId, TradeType tradeType);
     // 멤버별 전체 품앗이 게시글 리스트 조회
     List<Trade> getAllTradesByMember(Long memberId);
+    // 멤버별 활성화 품앗이 게시글 리스트 조회
+    List<Trade> getActiveTradesByMember(Long memberId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
@@ -2,7 +2,6 @@ package com.backend.DuruDuru.global.service.TradeService;
 
 import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.enums.TradeType;
-import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -11,4 +10,6 @@ public interface TradeQueryService {
     Trade getTrade(Long tradeId);
     // 나눔, 조회별 게시글 조회
     List<Trade> getNearTradesByType(Long memberId, TradeType tradeType);
+    // 멤버별 전체 품앗이 게시글 리스트 조회
+    List<Trade> getAllTradesByMember(Long memberId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
@@ -6,10 +6,6 @@ import com.backend.DuruDuru.global.domain.enums.TradeType;
 import com.backend.DuruDuru.global.repository.MemberRepository;
 import com.backend.DuruDuru.global.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +51,13 @@ public class TradeQueryServiceImpl implements TradeQueryService {
     @Transactional
     public List<Trade> getAllTradesByMember(Long memberId) {
         Member member = findMemberById(memberId);
-        return tradeRepository.findAllByMember(member);
+        return tradeRepository.findAllByMemberOrderByUpdatedAtDesc(member);
+    }
+
+    // 멤버별 활성화 품앗이 게시글 리스트 조회
+    @Override
+    @Transactional
+    public List<Trade> getActiveTradesByMember(Long memberId) {
+        return tradeRepository.findActiveTradesByMember(memberId);
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
@@ -47,7 +47,14 @@ public class TradeQueryServiceImpl implements TradeQueryService {
         double memberLat = member.getTown().getLatitude();
         double memberLon = member.getTown().getLongitude();
 
-        List<Trade> results = tradeRepository.findNearbyTrades(memberLat, memberLon, tradeType.name());
-        return results;
+        return tradeRepository.findNearbyTrades(memberLat, memberLon, tradeType.name());
+    }
+
+    // 멤버별 전체 품앗이 게시글 리스트 조회
+    @Override
+    @Transactional
+    public List<Trade> getAllTradesByMember(Long memberId) {
+        Member member = findMemberById(memberId);
+        return tradeRepository.findAllByMember(member);
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -88,7 +88,7 @@ public class TradeController {
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradeDetailDTO(trade));
     }
 
-    // 내 근처 품앗이 나눔/교환별 조회
+    // 내 근처 품앗이 나눔/교환별 리스트 조회
     @GetMapping("/near")
     @Operation(summary = "내 근처 품앗이 나눔/교환별 리스트 조회 API", description = "내 근처 품앗이 **프리뷰 리스트**를 나눔/교환별로 조회하는 API 입니다.")
     public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findNearTradeByType(
@@ -99,15 +99,18 @@ public class TradeController {
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradePreviewListDTO(tradeList));
     }
 
-    // 나의 품앗이 목록 조회 API
-    @GetMapping("/current")
+    // 나의 활성화 품앗이 리스트 조회
+    @GetMapping("/my/active")
     @Operation(summary = "나의 활성화 품앗이 리스트 조회 API", description = "나의 활성화된 품앗이 **프리뷰 리스트**를 조회하는 API 입니다.")
-    public ApiResponse<?> findCurrentTrade(){
-        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, null);
+    public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findCurrentTrade(
+            @RequestParam Long memberId
+    ){
+        List<Trade> tradeList = tradeQueryService.getActiveTradesByMember(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, TradeConverter.toTradePreviewListDTO(tradeList));
     }
 
-    // 나의 품앗이 기록 조회 API
-    @GetMapping("/history")
+    // 나의 전체 품앗이 리스트 조회
+    @GetMapping("/my/history")
     @Operation(summary = "나의 전체 품앗이 리스트 조회 API", description = "나의 전체 품앗이 **프리뷰 리스트**를 조회하는 API 입니다.")
     public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findHistoryTrade(
             @RequestParam Long memberId

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -90,7 +90,7 @@ public class TradeController {
 
     // 내 근처 품앗이 나눔/교환별 조회
     @GetMapping("/near")
-    @Operation(summary = "내 근처 품앗이 나눔/교환별 조회 API", description = "내 근처 품앗이 목록을 나눔/교환별로 조회하는 API 입니다. 페이징을 포함하며 query String 으로 page 번호를 주세요")
+    @Operation(summary = "내 근처 품앗이 나눔/교환별 리스트 조회 API", description = "내 근처 품앗이 **프리뷰 리스트**를 나눔/교환별로 조회하는 API 입니다.")
     public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findNearTradeByType(
             @RequestParam Long memberId,
             @RequestParam TradeType tradeType
@@ -101,16 +101,19 @@ public class TradeController {
 
     // 나의 품앗이 목록 조회 API
     @GetMapping("/current")
-    @Operation(summary = "나의 품앗이 목록 조회 API", description = "나의 품앗이 목록을 조회하는 API 입니다.")
+    @Operation(summary = "나의 활성화 품앗이 리스트 조회 API", description = "나의 활성화된 품앗이 **프리뷰 리스트**를 조회하는 API 입니다.")
     public ApiResponse<?> findCurrentTrade(){
         return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, null);
     }
 
     // 나의 품앗이 기록 조회 API
     @GetMapping("/history")
-    @Operation(summary = "나의 품앗이 기록 조회 API", description = "나의 품앗이 기록을 조회하는 API 입니다.")
-    public ApiResponse<?> findHistoryTrade(){
-        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, null);
+    @Operation(summary = "나의 전체 품앗이 리스트 조회 API", description = "나의 전체 품앗이 **프리뷰 리스트**를 조회하는 API 입니다.")
+    public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findHistoryTrade(
+            @RequestParam Long memberId
+    ){
+        List<Trade> tradeList = tradeQueryService.getAllTradesByMember(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.MEMBER_OK, TradeConverter.toTradePreviewListDTO(tradeList));
     }
 
     // 품앗이 링크 공유


### PR DESCRIPTION
## #️⃣연관된 이슈
> #142 

## 📝작업 내용
- GET /trade/my/active GET /trade/my/history로 엔드포인트 수정
- 나의 활성화 품앗이 리스트 조회 API 구현
- 나의 전체 품앗이 리스트 조회 API 구현

## 🔎코드 설명 및 참고 사항
- 나의 전체 품앗이 리스트 조회 API 성공
<img width="884" alt="스크린샷 2025-02-09 오전 10 53 56" src="https://github.com/user-attachments/assets/4f606b00-4883-4cff-b8df-d67429a97936" />

- 나의 활성화 품앗이 리스트 조회 API 성공
<img width="884" alt="스크린샷 2025-02-09 오전 10 54 38" src="https://github.com/user-attachments/assets/dc4f6112-e21d-4769-b020-f1553b2201a6" />


## 💬리뷰 요구사항
>
