### PR TITLE
Feat: 품앗이 게시글 이미지와 등록 가능한 게시글의 최대 개수 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
@@ -25,6 +25,7 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
     @Query(value = """
         SELECT * FROM trade
         WHERE trade_type = :tradeType
+        AND (status = 'ACTIVE' OR status = 'PROCEEDING')
         AND (6371 * acos(cos(radians(:memberLat)) * cos(radians(latitude)) * cos(radians(longitude) - radians(:memberLon)) + sin(radians(:memberLat)) * sin(radians(latitude)))) <= 1
         ORDER BY updated_at DESC
         """, nativeQuery = true)

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -59,6 +59,8 @@ public class TradeCommandServiceImpl implements TradeCommandService {
     public Trade createTrade(Long memberId, Long ingredientId, TradeRequestDTO.CreateTradeRequestDTO request, List<MultipartFile> tradeImgs) {
         Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
+
+        if(tradeImgs.size() > 5) throw new IllegalArgumentException("게시글에 등록할 수 있는 이미지의 수는 최대 5개입니다.");
         if(!member.getIngredients().contains(ingredient)) throw new IllegalArgumentException("접근 권한이 없는 식재료입니다.");
 
         Trade newTrade = TradeConverter.toCreateTrade(request, member, ingredient);
@@ -77,6 +79,7 @@ public class TradeCommandServiceImpl implements TradeCommandService {
                 newTrade.getTradeImgs().add(newTradeImage);
             }
         }
+
         return tradeRepository.save(newTrade);
     }
 
@@ -117,6 +120,8 @@ public class TradeCommandServiceImpl implements TradeCommandService {
 
         // 새로운 이미지를 추가한 경우
         if (request.getAddTradeImgs() != null) {
+            if(request.getAddTradeImgs().size() + trade.getTradeImgs().size() > 5) throw new IllegalArgumentException("게시글에 등록할 수 있는 이미지의 수는 최대 5개입니다.");
+
             for (MultipartFile img : request.getAddTradeImgs()) {
                 String tradeImgUrl = getImgUrl(img);
 

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.backend.DuruDuru.global.S3.AmazonS3Manager;
 import com.backend.DuruDuru.global.converter.TradeConverter;
 import com.backend.DuruDuru.global.converter.TradeImageConverter;
 import com.backend.DuruDuru.global.domain.entity.*;
+import com.backend.DuruDuru.global.domain.enums.Status;
 import com.backend.DuruDuru.global.repository.*;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -60,8 +60,9 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
 
-        if(tradeImgs.size() > 5) throw new IllegalArgumentException("게시글에 등록할 수 있는 이미지의 수는 최대 5개입니다.");
+        if(tradeRepository.findActiveTradesByMember(memberId).size() >= 4) throw new IllegalArgumentException("진행중인 품앗이 거래는 최대 4개까지 가능합니다.");
         if(!member.getIngredients().contains(ingredient)) throw new IllegalArgumentException("접근 권한이 없는 식재료입니다.");
+        if(tradeImgs.size() > 5) throw new IllegalArgumentException("게시글에 등록할 수 있는 이미지의 수는 최대 5개입니다.");
 
         Trade newTrade = TradeConverter.toCreateTrade(request, member, ingredient);
         member.addTrades(newTrade);
@@ -135,7 +136,16 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         if (request.getIngredientCount() != null) trade.setIngredientCount(request.getIngredientCount());
         if (request.getBody() != null) trade.setBody(request.getBody());
         if (request.getTradeType() != null) trade.setTradeType(request.getTradeType());
-        if (request.getStatus() != null) trade.setStatus(request.getStatus());
+        if (request.getStatus() != null) {
+            Status requestStatus = request.getStatus();
+
+            // 완료된 품앗이를 거래 전, 거래 중으로 바꾸는 경우
+            if((requestStatus == Status.ACTIVE || requestStatus == Status.PROCEEDING) && tradeRepository.findActiveTradesByMember(memberId).size() >= 4) {
+                throw new IllegalArgumentException("진행중인 품앗이 거래는 최대 4개까지 가능합니다.");
+            } else {
+                trade.setStatus(requestStatus);
+            }
+        }
 
         return tradeRepository.save(trade);
     }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -72,7 +72,7 @@ public class TradeController {
 
     // 품앗이 게시글 수정
     @PatchMapping(value = "/{trade_id}", consumes = "multipart/form-data")
-    @Operation(summary = "품앗이 게시글 수정 API", description = "특정 품앗이를 수정하는 API 입니다.")
+    @Operation(summary = "품앗이 게시글 수정 API", description = "특정 품앗이를 수정하는 API 입니다. 삭제할 이미지는 해당 이미지의 id값으로 넣어주세요.")
     public ApiResponse<TradeResponseDTO.TradeDetailResultDTO> updateTrade(
             @PathVariable("trade_id") Long tradeId,
             @RequestParam Long memberId,


### PR DESCRIPTION
## #️⃣연관된 이슈
> #89 

## 📝작업 내용
> - 품앗이 게시글에 이미지 최대 5개까지 업로드 가능하도록 수정
> - 진행중인 품앗이 게시글 최대 4개까지 등록 가능하도록 구현

## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
