### PR TITLE
Refactor: 식재료 이미지 중복 저장 문제 해결

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/S3/AmazonS3Manager.java
+++ b/src/main/java/com/backend/DuruDuru/global/S3/AmazonS3Manager.java
@@ -47,31 +47,41 @@ public class AmazonS3Manager {
 //            log.error("Error deleting file from S3: {}", e.getMessage());
 //        }
 //    }
-public void deleteFile(String fileUrl) {
-    try {
-        // S3 Key 추출
-        String bucketUrl = amazonS3.getUrl(s3Config.getBucket(), "").toString();
-        if (!fileUrl.startsWith(bucketUrl)) {
-            throw new IllegalArgumentException("Invalid file URL: " + fileUrl);
+//public void deleteFile(String fileUrl) {
+//    try {
+//        // S3 Key 추출
+//        String bucketUrl = amazonS3.getUrl(s3Config.getBucket(), "").toString();
+//        if (!fileUrl.startsWith(bucketUrl)) {
+//            throw new IllegalArgumentException("Invalid file URL: " + fileUrl);
+//        }
+//        String keyName = fileUrl.substring(bucketUrl.length());
+//        log.info("Attempting to delete file: bucket={}, keyName={}", s3Config.getBucket(), keyName);
+//
+//        // S3 파일 삭제 요청
+//        amazonS3.deleteObject(s3Config.getBucket(), keyName);
+//        log.info("Successfully deleted file: bucket={}, keyName={}", s3Config.getBucket(), keyName);
+//    } catch (AmazonServiceException e) {
+//        log.error("S3 Service Exception: {}", e.getErrorMessage());
+//        log.error("HTTP Status Code: {}", e.getStatusCode());
+//        log.error("AWS Error Code: {}", e.getErrorCode());
+//        log.error("Request ID: {}", e.getRequestId());
+//        throw e;
+//    } catch (Exception e) {
+//        log.error("Error deleting file from S3: {}", e.getMessage());
+//        throw e;
+//    }
+//}
+
+    public void deleteFile(String fileUrl) {
+        String[] segments = fileUrl.split("/");
+        String keyName = s3Config.getFilesPath() + '/' + segments[segments.length - 1];
+
+        try {
+            amazonS3.deleteObject(s3Config.getBucket(), keyName);
+        } catch (Exception e) {
+            log.error("error at AmazonS3Manager deleteFile : {}", (Object) e.getStackTrace());
         }
-        String keyName = fileUrl.substring(bucketUrl.length());
-        log.info("Attempting to delete file: bucket={}, keyName={}", s3Config.getBucket(), keyName);
-
-        // S3 파일 삭제 요청
-        amazonS3.deleteObject(s3Config.getBucket(), keyName);
-        log.info("Successfully deleted file: bucket={}, keyName={}", s3Config.getBucket(), keyName);
-    } catch (AmazonServiceException e) {
-        log.error("S3 Service Exception: {}", e.getErrorMessage());
-        log.error("HTTP Status Code: {}", e.getStatusCode());
-        log.error("AWS Error Code: {}", e.getErrorCode());
-        log.error("Request ID: {}", e.getRequestId());
-        throw e;
-    } catch (Exception e) {
-        log.error("Error deleting file from S3: {}", e.getMessage());
-        throw e;
     }
-}
-
 
 
     public String generatePostName(Uuid uuid) {

--- a/src/main/java/com/backend/DuruDuru/global/converter/IngredientConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/IngredientConverter.java
@@ -93,7 +93,6 @@ public class IngredientConverter {
                 .build();
     }
 
-
     public static IngredientResponseDTO.IngredientImageDTO toIngredientImageDTO(Ingredient ingredient) {
         return IngredientResponseDTO.IngredientImageDTO.builder()
                 .memberId(ingredient.getMember().getMemberId())

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Ingredient.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Ingredient.java
@@ -79,6 +79,22 @@ public class Ingredient extends BaseEntity {
     @OneToOne(mappedBy = "ingredient", cascade = CascadeType.ALL, orphanRemoval = true)
     private IngredientImg ingredientImg;
 
+    @Builder
+    public Ingredient(String ingredientName, Long count, LocalDate purchaseDate, LocalDate expiryDate, StorageType storageType, MajorCategory majorCategory, MinorCategory minorCategory, Fridge fridge, Member member, Receipt receipt, IngredientImg ingredientImg) {
+        this.ingredientName = ingredientName;
+        this.count = count;
+        this.purchaseDate = purchaseDate;
+        this.expiryDate = expiryDate;
+        this.storageType = storageType;
+        this.majorCategory = majorCategory;
+        this.minorCategory = minorCategory;
+        this.fridge = fridge;
+        this.member = member;
+        this.receipt = receipt;
+        this.ingredientImg = new IngredientImg(this, "");
+        calculateDDay();
+    }
+
 //    @OneToMany(mappedBy = "ingredient", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private List<IngredientCategory> ingredientCategoryList = new ArrayList<>();
 
@@ -111,9 +127,17 @@ public class Ingredient extends BaseEntity {
     }
 
     public void setIngredientImg(IngredientImg ingredientImg) {
-        this.ingredientImg = ingredientImg;
-        ingredientImg.setIngredient(this);
+        if (ingredientImg == null) {
+            this.ingredientImg = IngredientImg.builder()
+                    .ingredientImgUrl("https://duruduru.s3.ap-northeast-2.amazonaws.com/76636494-cfa7-4b1b-8649-2eda45f1be8a")
+                    .ingredient(this)
+                    .build();
+        } else {
+            this.ingredientImg = ingredientImg;
+            ingredientImg.setIngredient(this);
+        }
     }
+
 
     public void calculateDDay() {
         LocalDate today = LocalDate.now();
@@ -130,6 +154,7 @@ public class Ingredient extends BaseEntity {
     public String getFormattedDDay() {
         return DateFormatter.formatRemainingDays(this.dDay);
     }
+
 
 
 

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/IngredientImg.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/IngredientImg.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Builder
+//@Builder
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,6 +19,12 @@ public class IngredientImg {
     @JoinColumn(name = "ingredient_id", nullable = false)
     private Ingredient ingredient;
 
-    @Column(name = "ingredient_img_url", length = 200, nullable = true)
+    @Column(name = "image_url", nullable = true, columnDefinition = "varchar(500)")
     private String ingredientImgUrl;
+
+    @Builder
+    public IngredientImg(Ingredient ingredient, String ingredientImgUrl) {
+        this.ingredient = ingredient;
+        this.ingredientImgUrl = ingredientImgUrl;
+    }
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientImageRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientImageRepository.java
@@ -1,7 +1,18 @@
 package com.backend.DuruDuru.global.repository;
 
 import com.backend.DuruDuru.global.domain.entity.IngredientImg;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface IngredientImageRepository extends JpaRepository<IngredientImg, Long> {
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM IngredientImg img WHERE img.ingredient.ingredientId = :ingredientId")
+    void deleteByIngredientId(@Param("ingredientId") Long ingredientId);
+
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandService.java
@@ -14,8 +14,6 @@ public interface IngredientCommandService {
     Ingredient registerPurchaseDate(Long memberId, Long ingredientId, IngredientRequestDTO.PurchaseDateRequestDTO request);
     Ingredient setStorageType(Long memberId, Long ingredientId, IngredientRequestDTO.StorageTypeRequestDTO request);
 
-    //public ApiResponse<IngredientResponseDTO.IngredientImageDTO> registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request);
     Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request);
-
     Ingredient setCategory(Long memberId, Long ingredientId, IngredientRequestDTO.SetCategoryRequestDTO request);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandService.java
@@ -1,7 +1,9 @@
 package com.backend.DuruDuru.global.service.IngredientService;
 
+import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
+import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
 
 public interface IngredientCommandService {
 
@@ -12,6 +14,7 @@ public interface IngredientCommandService {
     Ingredient registerPurchaseDate(Long memberId, Long ingredientId, IngredientRequestDTO.PurchaseDateRequestDTO request);
     Ingredient setStorageType(Long memberId, Long ingredientId, IngredientRequestDTO.StorageTypeRequestDTO request);
 
+    //public ApiResponse<IngredientResponseDTO.IngredientImageDTO> registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request);
     Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request);
 
     Ingredient setCategory(Long memberId, Long ingredientId, IngredientRequestDTO.SetCategoryRequestDTO request);

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandServiceImpl.java
@@ -107,61 +107,33 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
     }
 
 
-//    @Transactional
-//    @Override
-//    public ApiResponse<IngredientResponseDTO.IngredientImageDTO> registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request){//Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request) {
-//        Ingredient ingredient = findIngredientById(ingredientId);
-//
-//        if (ingredient.getIngredientImg() != null) {
-//            s3Manager.deleteFile(ingredient.getIngredientImg().getIngredientImgUrl());
-//            ingredientImageRepository.deleteByIngredientId(ingredientId);
-//            entityManager.flush(); // DB에서 Id에 해당하는 튜플삭제
-//            entityManager.clear(); // 영속성 컨텍스트 초기화
-//            ingredient.setIngredientImg(null);
-//        }
-//
-//        String uuid = UUID.randomUUID().toString();
-//        Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
-//        String fileUrl = s3Manager.uploadFile(s3Manager.generatePostName(savedUuid), request.getImage());
-//
-//        IngredientImg ingredientImg = IngredientImg.builder()
-//                .ingredientImgUrl(fileUrl)
-//                .ingredient(ingredient)
-//                .build();
-//
-//        ingredient.setIngredientImg(ingredientImg);
-//        ingredientImageRepository.save(ingredientImg);
-//
-//        IngredientResponseDTO.IngredientImageDTO response = new IngredientResponseDTO.IngredientImageDTO(ingredientImg.getIngredientImgUrl());
-//        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, response);
-//    }
-@Transactional
-@Override
-public Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request) {
-    Ingredient ingredient = findIngredientById(ingredientId);
+    @Transactional
+    @Override
+    public Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request) {
+        Ingredient ingredient = findIngredientById(ingredientId);
 
-    if (ingredient.getIngredientImg() != null) {
-        s3Manager.deleteFile(ingredient.getIngredientImg().getIngredientImgUrl());
-        ingredientImageRepository.deleteByIngredientId(ingredientId);
-        entityManager.flush(); // DB에서 Id에 해당하는 튜플 삭제
-        entityManager.clear(); // 영속성 컨텍스트 초기화
-        ingredient.setIngredientImg(null);
+        if (ingredient.getIngredientImg() != null) {
+            s3Manager.deleteFile(ingredient.getIngredientImg().getIngredientImgUrl());
+            ingredientImageRepository.deleteByIngredientId(ingredientId);
+            entityManager.flush(); // DB에서 Id에 해당하는 튜플 삭제
+            entityManager.clear(); // 영속성 컨텍스트 초기화
+            ingredient.setIngredientImg(null);
+        }
+
+        String uuid = UUID.randomUUID().toString();
+        Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
+        String fileUrl = s3Manager.uploadFile(s3Manager.generatePostName(savedUuid), request.getImage());
+
+        IngredientImg ingredientImg = IngredientImg.builder()
+                .ingredientImgUrl(fileUrl)
+                .ingredient(ingredient)
+                .build();
+
+        ingredient.setIngredientImg(ingredientImg);
+        ingredientImageRepository.save(ingredientImg);
+
+        return ingredient;
     }
-
-    String uuid = UUID.randomUUID().toString();
-    Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
-    String fileUrl = s3Manager.uploadFile(s3Manager.generatePostName(savedUuid), request.getImage());
-
-    IngredientImg ingredientImg = IngredientImg.builder()
-            .ingredientImgUrl(fileUrl)
-            .ingredient(ingredient)
-            .build();
-
-    ingredient.setIngredientImg(ingredientImg);
-    ingredientImageRepository.save(ingredientImg);
-
-    return ingredient;
-}
 
 
     @Transactional

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandServiceImpl.java
@@ -1,12 +1,15 @@
 package com.backend.DuruDuru.global.service.IngredientService;
 
 import com.backend.DuruDuru.global.S3.AmazonS3Manager;
+import com.backend.DuruDuru.global.apiPayload.ApiResponse;
+import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
 import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.*;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 import com.backend.DuruDuru.global.domain.enums.StorageType;
 import com.backend.DuruDuru.global.repository.*;
+import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -104,35 +107,62 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
     }
 
 
+//    @Transactional
+//    @Override
+//    public ApiResponse<IngredientResponseDTO.IngredientImageDTO> registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request){//Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request) {
+//        Ingredient ingredient = findIngredientById(ingredientId);
+//
+//        if (ingredient.getIngredientImg() != null) {
+//            s3Manager.deleteFile(ingredient.getIngredientImg().getIngredientImgUrl());
+//            ingredientImageRepository.deleteByIngredientId(ingredientId);
+//            entityManager.flush(); // DB에서 Id에 해당하는 튜플삭제
+//            entityManager.clear(); // 영속성 컨텍스트 초기화
+//            ingredient.setIngredientImg(null);
+//        }
+//
+//        String uuid = UUID.randomUUID().toString();
+//        Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
+//        String fileUrl = s3Manager.uploadFile(s3Manager.generatePostName(savedUuid), request.getImage());
+//
+//        IngredientImg ingredientImg = IngredientImg.builder()
+//                .ingredientImgUrl(fileUrl)
+//                .ingredient(ingredient)
+//                .build();
+//
+//        ingredient.setIngredientImg(ingredientImg);
+//        ingredientImageRepository.save(ingredientImg);
+//
+//        IngredientResponseDTO.IngredientImageDTO response = new IngredientResponseDTO.IngredientImageDTO(ingredientImg.getIngredientImgUrl());
+//        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, response);
+//    }
+@Transactional
+@Override
+public Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request) {
+    Ingredient ingredient = findIngredientById(ingredientId);
 
-    @Transactional
-    @Override
-    public Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request) {
-        Ingredient ingredient = findIngredientById(ingredientId);
-        if (ingredient.getIngredientImg() != null) {
-            IngredientImg existingImage = ingredient.getIngredientImg();
-
-            s3Manager.deleteFile(existingImage.getIngredientImgUrl());
-            ingredient.setIngredientImg(null);
-
-            ingredientRepository.save(ingredient);
-            // 기존 업로드된 이미지 삭제 작업 DB에 반영
-            entityManager.flush();
-            entityManager.clear();
-        }
-        // new 식재료 이미지 업로드
-        String uuid = UUID.randomUUID().toString();
-        String fileUrl = s3Manager.uploadFile(uuid, request.getImage());
-
-        IngredientImg newImage = IngredientImg.builder()
-                .ingredientImgUrl(fileUrl)
-                .ingredient(ingredient)
-                .build();
-        ingredient.setIngredientImg(newImage);
-
-        ingredientImageRepository.save(newImage); // 먼저 이미지 저장한 다음
-        return ingredientRepository.save(ingredient); // 이후 식재료 저장
+    if (ingredient.getIngredientImg() != null) {
+        s3Manager.deleteFile(ingredient.getIngredientImg().getIngredientImgUrl());
+        ingredientImageRepository.deleteByIngredientId(ingredientId);
+        entityManager.flush(); // DB에서 Id에 해당하는 튜플 삭제
+        entityManager.clear(); // 영속성 컨텍스트 초기화
+        ingredient.setIngredientImg(null);
     }
+
+    String uuid = UUID.randomUUID().toString();
+    Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
+    String fileUrl = s3Manager.uploadFile(s3Manager.generatePostName(savedUuid), request.getImage());
+
+    IngredientImg ingredientImg = IngredientImg.builder()
+            .ingredientImgUrl(fileUrl)
+            .ingredient(ingredient)
+            .build();
+
+    ingredient.setIngredientImg(ingredientImg);
+    ingredientImageRepository.save(ingredientImg);
+
+    return ingredient;
+}
+
 
     @Transactional
     @Override

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -40,7 +40,8 @@ public class IngredientController {
     @Operation(summary = "추가할 식재료 사진 등록 API", description = "추가할 식재료의 사진을 등록하는 API 입니다.")
     public ApiResponse<IngredientResponseDTO.IngredientImageDTO> updateIngredientPhoto(@ModelAttribute IngredientRequestDTO.IngredientImageRequestDTO request,
                                                                                        @RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId) {
-        Ingredient ingredient = ingredientCommandService.registerIngredientImage(memberId, ingredientId, request);
+        //return ingredientCommandService.registerIngredientImage(memberId, ingredientId, request);
+                Ingredient ingredient = ingredientCommandService.registerIngredientImage(memberId, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toIngredientImageDTO(ingredient));
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -40,7 +40,6 @@ public class IngredientController {
     @Operation(summary = "추가할 식재료 사진 등록 API", description = "추가할 식재료의 사진을 등록하는 API 입니다.")
     public ApiResponse<IngredientResponseDTO.IngredientImageDTO> updateIngredientPhoto(@ModelAttribute IngredientRequestDTO.IngredientImageRequestDTO request,
                                                                                        @RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId) {
-        //return ingredientCommandService.registerIngredientImage(memberId, ingredientId, request);
                 Ingredient ingredient = ingredientCommandService.registerIngredientImage(memberId, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toIngredientImageDTO(ingredient));
     }

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
@@ -97,16 +97,6 @@ public class IngredientResponseDTO {
         String ingredientImageUrl;
     }
 
-//    @JsonInclude(JsonInclude.Include.NON_NULL)
-//    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-//    @Builder
-//    public record IngredientImageDTO(String url) {
-//        public static IngredientImageDTO of(String url) {
-//            return IngredientImageDTO.builder()
-//                    .url(url)
-//                    .build();
-//        }
-//    }
 
     @Getter
     @Setter

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
@@ -2,6 +2,9 @@ package com.backend.DuruDuru.global.web.dto.Ingredient;
 
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -93,6 +96,17 @@ public class IngredientResponseDTO {
         String ingredientName;
         String ingredientImageUrl;
     }
+
+//    @JsonInclude(JsonInclude.Include.NON_NULL)
+//    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+//    @Builder
+//    public record IngredientImageDTO(String url) {
+//        public static IngredientImageDTO of(String url) {
+//            return IngredientImageDTO.builder()
+//                    .url(url)
+//                    .build();
+//        }
+//    }
 
     @Getter
     @Setter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #83 

## 📝작업 내용
> - 식재료 이미지 중복 저장 문제 해결
> - 기존에 이미지가 설정되어 있는 식재료의 이미지를 재설정시 기존 s3에 올라간 이미지를 삭제한 후 새로 저장하는 로직 오류 수정

## 🔎코드 설명 및 참고 사항
> - deleteByIngredientId() 실행 후 즉시 flush()를 호출하여 DB에서 삭제 반영
> - flush() 후 clear()를 호출하여 영속성 컨텍스트 초기화
> - setIngredientImg(null)은 flush() 이후에 실행

## 💬리뷰 요구사항
>
