### PR TITLE
Feat: 내 근처 품앗이 최신순, 소비기한 임박순/여유순 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
@@ -21,11 +21,11 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
         """, nativeQuery = true)
     List<Trade> findActiveTradesByMember(@Param("memberId") Long memberId);
 
-    // 사용자와의 거리가 1km 이내인 게시글 리스트 반환
+    // 품앗이 타입별로 사용자와의 거리가 1km 이내 게시글 리스트 반환
     @Query(value = """
         SELECT * FROM trade
-        WHERE trade_type = :tradeType
-        AND (status = 'ACTIVE' OR status = 'PROCEEDING')
+        WHERE (status = 'ACTIVE' OR status = 'PROCEEDING')
+        AND trade_type = :tradeType
         AND (6371 * acos(cos(radians(:memberLat)) * cos(radians(latitude)) * cos(radians(longitude) - radians(:memberLon)) + sin(radians(:memberLat)) * sin(radians(latitude)))) <= 1
         ORDER BY updated_at DESC
         """, nativeQuery = true)
@@ -33,6 +33,18 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
             @Param("memberLat") double memberLat,
             @Param("memberLon") double memberLon,
             @Param("tradeType") String tradeType
+    );
+
+    // 사용자와의 거리가 가까운 게시글을 최신순으로 정렬하여 리스트 반환
+    @Query(value = """
+        SELECT * FROM trade
+        WHERE (status = 'ACTIVE' OR status = 'PROCEEDING')
+        AND (6371 * acos(cos(radians(:memberLat)) * cos(radians(latitude)) * cos(radians(longitude) - radians(:memberLon)) + sin(radians(:memberLat)) * sin(radians(latitude)))) <= 1
+        ORDER BY updated_at DESC
+        """, nativeQuery = true)
+    List<Trade> findRecentTrades(
+            @Param("memberLat") double memberLat,
+            @Param("memberLon") double memberLon
     );
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/TradeRepository.java
@@ -61,5 +61,19 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
             @Param("memberLon") double memberLon
     );
 
+    // 사용자와의 거리가 가까운 게시글을 소비기한 여유순으로 정렬하여 리스트 반환
+    @Query(value = """
+        SELECT t.* FROM trade t
+        JOIN ingredient i ON t.ingredient_id = i.ingredient_id
+        WHERE t.ingredient_id = i.ingredient_id
+        AND t.status IN ('ACTIVE', 'PROCEEDING')
+        AND (6371 * acos(cos(radians(:memberLat)) * cos(radians(latitude)) * cos(radians(longitude) - radians(:memberLon)) + sin(radians(:memberLat)) * sin(radians(latitude)))) <= 1
+        ORDER BY i.d_day DESC
+        """, nativeQuery = true)
+    List<Trade> findFarExpiryTrades(
+            @Param("memberLat") double memberLat,
+            @Param("memberLon") double memberLon
+    );
+
 }
 

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
@@ -18,4 +18,6 @@ public interface TradeQueryService {
     List<Trade> getRecentTrades(Long memberId);
     // 근처 품앗이 소비기한 임박순 조회
     List<Trade> getNearExpiryTrade(Long memberId);
+    // 근처 품앗이 소비기한 여유순 조회
+    List<Trade> getFarExpiryTrade(Long memberId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
@@ -8,10 +8,12 @@ import java.util.List;
 public interface TradeQueryService {
     // 품앗이 게시글 상세 조회
     Trade getTrade(Long tradeId);
-    // 나눔, 조회별 게시글 조회
+    // 가까운 게시글 중에서 나눔, 조회별 게시글 조회
     List<Trade> getNearTradesByType(Long memberId, TradeType tradeType);
     // 멤버별 전체 품앗이 게시글 리스트 조회
     List<Trade> getAllTradesByMember(Long memberId);
     // 멤버별 활성화 품앗이 게시글 리스트 조회
     List<Trade> getActiveTradesByMember(Long memberId);
+    // 근처 품앗이 최신 등록순 조회
+    List<Trade> getRecentTrades(Long memberId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryService.java
@@ -16,4 +16,6 @@ public interface TradeQueryService {
     List<Trade> getActiveTradesByMember(Long memberId);
     // 근처 품앗이 최신 등록순 조회
     List<Trade> getRecentTrades(Long memberId);
+    // 근처 품앗이 소비기한 임박순 조회
+    List<Trade> getNearExpiryTrade(Long memberId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
@@ -76,4 +76,12 @@ public class TradeQueryServiceImpl implements TradeQueryService {
         Member member = findMemberById(memberId);
         return tradeRepository.findNearExpiryTrades(member.getTown().getLatitude(), member.getTown().getLongitude());
     }
+
+    // 근처 품앗이 소비기한 여유순 조회
+    @Override
+    @Transactional
+    public List<Trade> getFarExpiryTrade(Long memberId) {
+        Member member = findMemberById(memberId);
+        return tradeRepository.findFarExpiryTrades(member.getTown().getLatitude(), member.getTown().getLongitude());
+    }
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
@@ -68,4 +68,12 @@ public class TradeQueryServiceImpl implements TradeQueryService {
         Member member = findMemberById(memberId);
         return tradeRepository.findRecentTrades(member.getTown().getLatitude(), member.getTown().getLongitude());
     }
+
+    // 근처 품앗이 소비기한 임박순 조회
+    @Override
+    @Transactional
+    public List<Trade> getNearExpiryTrade(Long memberId) {
+        Member member = findMemberById(memberId);
+        return tradeRepository.findNearExpiryTrades(member.getTown().getLatitude(), member.getTown().getLongitude());
+    }
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
@@ -60,4 +60,12 @@ public class TradeQueryServiceImpl implements TradeQueryService {
     public List<Trade> getActiveTradesByMember(Long memberId) {
         return tradeRepository.findActiveTradesByMember(memberId);
     }
+
+    // 근처 품앗이 최신 등록순 조회
+    @Override
+    @Transactional
+    public List<Trade> getRecentTrades(Long memberId) {
+        Member member = findMemberById(memberId);
+        return tradeRepository.findRecentTrades(member.getTown().getLatitude(), member.getTown().getLongitude());
+    }
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -149,8 +149,11 @@ public class TradeController {
     // 내 근처 품앗이 소비기한 여유순 리스트 조회
     @GetMapping("/near/far-expiry")
     @Operation(summary = "내 근처 품앗이 소비기한 여유순 리스트 조회 API", description = "내 근처 게시글 중에서 소비기한 여유순으로 **프리뷰 리스트**를 조회하는 API 입니다.")
-    public ApiResponse<?> findFarExpiryTrade(){
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
+    public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findFarExpiryTrade(
+            @RequestParam Long memberId
+    ) {
+        List<Trade> tradeList = tradeQueryService.getFarExpiryTrade(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradePreviewListDTO(tradeList));
     }
 
     // 다른 품앗이 둘러보기

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -129,8 +129,11 @@ public class TradeController {
     // 내 근처 품앗이 최신 등록순 리스트 조회
     @GetMapping("/near/recent")
     @Operation(summary = "내 근처 품앗이 최신 등록순 리스트 조회 API", description = "내 근처 게시글 중에서 최신 등록순으로 **프리뷰 리스트**를 조회하는 API 입니다.")
-    public ApiResponse<?> findRecentTrade(){
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
+    public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findRecentTrade(
+            @RequestParam Long memberId
+    ){
+        List<Trade> tradeList = tradeQueryService.getRecentTrades(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradePreviewListDTO(tradeList));
     }
 
     // 내 근처 품앗이 소비기한 임박순 리스트 조회

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -139,8 +139,11 @@ public class TradeController {
     // 내 근처 품앗이 소비기한 임박순 리스트 조회
     @GetMapping("/near/near-expiry")
     @Operation(summary = "내 근처 품앗이 소비기한 임박순 리스트 조회 API", description = "내 근처 게시글 중에서 소비기한 임박순으로 **프리뷰 리스트**를 조회하는 API 입니다.")
-    public ApiResponse<?> findNearExpiryTrade(){
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
+    public ApiResponse<TradeResponseDTO.TradePreviewListDTO> findNearExpiryTrade(
+            @RequestParam Long memberId
+    ) {
+        List<Trade> tradeList = tradeQueryService.getNearExpiryTrade(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toTradePreviewListDTO(tradeList));
     }
 
     // 내 근처 품앗이 소비기한 여유순 리스트 조회


### PR DESCRIPTION
## #️⃣연관된 이슈
> #153 

## 📝작업 내용
> 내 근처 품앗이 최신순, 소비기한 임박순/여유순 리스트 조회 API 구현

## 🔎코드 설명 및 참고 사항
- 내 근처 품앗이 최신 등록순 API 구현
- 내 근처 품앗이 소비기한 임박순 API 구현
- 내 근처 품앗이 소비기한 여유순 API 구현 


## 💬리뷰 요구사항
>
