### PR TITLE
Feat: 품앗이 찜하기 등록/취소 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
@@ -39,8 +39,8 @@ public class SecurityConfig {
                                 // Trade 관련 접근
                                 .requestMatchers("/trade/", "trade/{trade_id}", "/trade/my/active", "/trade/my/history", "/trade/my/like").permitAll()
                                 .requestMatchers("/trade/near/{trade_type}", "/trade/near/recent", "trade/near/near-expiry", "trade/near/far-expiry").permitAll()
-                                .requestMatchers("trade/like/{member_id}/{trade_id}", "/trade/like/delete/{trade_id}", "/trade/like/count/{trade_id}").permitAll()
-                                .requestMatchers("trade/other-trade","/trade/shareUrl", "/trade/recommend/today", "/trade/keyword/alert").permitAll()
+                                .requestMatchers("trade/like/{trade_id}", "/trade/like/{trade_id}/delete", "/trade/like/{trade_id}/count").permitAll()
+                                .requestMatchers("trade/other-trade", "/trade/recommend/today", "/trade/keyword/alert").permitAll()
                                 // Ingredient 관련 접근
                                 .requestMatchers("/ingredient/{ingredient_id}/photo","/ingredient/{ingredient_id}/purchase-date", "/ingredient/").permitAll()
                                 .requestMatchers("/ingredient/{ingredient_id}","/ingredient/{ingredient_id}/category", "/ingredient/{ingredient_id}/storage-type").permitAll()

--- a/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
@@ -1,6 +1,7 @@
 package com.backend.DuruDuru.global.converter;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.LikeTrade;
 import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.enums.Status;
@@ -27,6 +28,7 @@ public class TradeConverter {
                 .eupmyeondong(trade.getEupmyeondong())
                 .status(trade.getStatus())
                 .tradeType(trade.getTradeType())
+                .likeCount(trade.getLikeCount())
                 .tradeImgs(trade.getTradeImgs())
                 .createdAt(trade.getCreatedAt())
                 .updatedAt(trade.getUpdatedAt())
@@ -46,6 +48,7 @@ public class TradeConverter {
                 .status(Status.ACTIVE)
                 .tradeType(request.getTradeType())
                 .tradeImgs(new ArrayList<>())
+                .likeCount(0L)
                 .build();
     }
 
@@ -60,6 +63,7 @@ public class TradeConverter {
                 .eupmyeondong(trade.getEupmyeondong())
                 .status(trade.getStatus())
                 .tradeType(trade.getTradeType())
+                .likeCount(trade.getLikeCount())
                 .thumbnailImgUrl(
                         (trade.getTradeImgs() != null && !trade.getTradeImgs().isEmpty())
                         ? trade.getTradeImgs().get(0).getTradeImgUrl() : null)      // TradeImgs의 첫 번째 이미지를 thumbnailImg로 자동 등록
@@ -75,6 +79,21 @@ public class TradeConverter {
         return TradeResponseDTO.TradePreviewListDTO.builder()
                 .totalCount(tradePreViewDTOList.size())
                 .tradeList(tradePreViewDTOList)
+                .build();
+    }
+
+    public static LikeTrade toLikeTrade(Member member, Trade trade) {
+        return LikeTrade.builder()
+                .member(member)
+                .trade(trade)
+                .build();
+    }
+
+    public static TradeResponseDTO.LikeTradeResultDTO toLikeTradeResultDTO(LikeTrade likeTrade) {
+        return TradeResponseDTO.LikeTradeResultDTO.builder()
+                .memberId(likeTrade.getMember().getMemberId())
+                .tradeId(likeTrade.getTrade().getTradeId())
+                .likeCount(likeTrade.getTrade().getLikeCount())
                 .build();
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Member.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Member.java
@@ -110,4 +110,11 @@ public class Member extends BaseEntity {
         }
     }
 
+    public void addLikeTrades(LikeTrade likeTrade) {
+        this.likeTrades.add(likeTrade);
+        if (likeTrade.getMember() != this) {
+            likeTrade.setMember(this);
+        }
+    }
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Trade.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Trade.java
@@ -48,6 +48,9 @@ public class Trade extends BaseEntity {
     @Column(name = "eupmyeondong", nullable = false, columnDefinition = "varchar(50)")
     private String eupmyeondong;
 
+    @Column(name = "like_count", columnDefinition = "bigint")
+    private Long likeCount = 0L;
+
     @OneToMany(mappedBy = "trade", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChattingRoom> chattingRooms = new ArrayList<>();
 
@@ -71,5 +74,16 @@ public class Trade extends BaseEntity {
         this.ingredientCount = trade.getIngredientCount();
         this.status = trade.getStatus();
         this.tradeType = trade.getTradeType();
+    }
+
+    public void addLikeTrades(LikeTrade likeTrade) {
+        this.likeTrades.add(likeTrade);
+        if (likeTrade.getTrade() != this) {
+            likeTrade.setTrade(this);
+        }
+    }
+
+    public void increaseLikeCount() {
+        likeCount++;
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Trade.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Trade.java
@@ -86,4 +86,8 @@ public class Trade extends BaseEntity {
     public void increaseLikeCount() {
         likeCount++;
     }
+
+    public void decreaseLikeCount() {
+        likeCount--;
+    }
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/LikeTradeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/LikeTradeRepository.java
@@ -1,0 +1,11 @@
+package com.backend.DuruDuru.global.repository;
+
+import com.backend.DuruDuru.global.domain.entity.LikeTrade;
+import com.backend.DuruDuru.global.domain.entity.Member;
+import com.backend.DuruDuru.global.domain.entity.Trade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeTradeRepository extends JpaRepository<LikeTrade, Long> {
+
+    LikeTrade findByMemberAndTrade(Member member, Trade trade);
+}

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
@@ -16,4 +16,6 @@ public interface TradeCommandService {
     Trade updateTrade(Long memberId, Long tradeId, TradeRequestDTO.UpdateTradeRequestDTO request);
     // 찜하기 등록
     LikeTrade createLike(Long memberId, Long tradeId);
+    // 찜하기 취소
+    void deleteLike(Long memberId, Long tradeId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
@@ -1,5 +1,6 @@
 package com.backend.DuruDuru.global.service.TradeService;
 
+import com.backend.DuruDuru.global.domain.entity.LikeTrade;
 import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,4 +14,6 @@ public interface TradeCommandService {
     void deleteTrade(Long memberId, Long tradeId);
     // 품앗이 게시글 수정
     Trade updateTrade(Long memberId, Long tradeId, TradeRequestDTO.UpdateTradeRequestDTO request);
+    // 찜하기 등록
+    LikeTrade createLike(Long memberId, Long tradeId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -23,6 +23,7 @@ public class TradeCommandServiceImpl implements TradeCommandService {
     private final TradeImageRepository tradeImageRepository;
     private final MemberRepository memberRepository;
     private final IngredientRepository ingredientRepository;
+    private final LikeTradeRepository likeTradeRepository;
     private final UuidRepository uuidRepository;
     private final AmazonS3Manager s3Manager;
 
@@ -167,6 +168,28 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         }
 
         return tradeRepository.save(trade);
+    }
+
+    // 찜하기 등록
+    @Override
+    @Transactional
+    public LikeTrade createLike(Long memberId, Long tradeId) {
+        Member member = findMemberById(memberId);
+        Trade trade = findTradeById(tradeId);
+
+        if(likeTradeRepository.findByMemberAndTrade(member, trade) != null) {
+            throw new IllegalArgumentException("이미 찜하기한 게시글입니다.");
+        }
+
+        // LieTrade 엔티티 생성 및 저장
+        LikeTrade likeTrade = TradeConverter.toLikeTrade(member, trade);
+        member.addLikeTrades(likeTrade);
+        trade.addLikeTrades(likeTrade);
+
+        // 찜하기 수 증가
+        trade.increaseLikeCount();
+
+        return likeTradeRepository.save(likeTrade);
     }
 
 

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -192,6 +192,22 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         return likeTradeRepository.save(likeTrade);
     }
 
+    @Override
+    @Transactional
+    public void deleteLike(Long memberId, Long tradeId) {
+        Member member = findMemberById(memberId);
+        Trade trade = findTradeById(tradeId);
+
+        LikeTrade likeTrade = likeTradeRepository.findByMemberAndTrade(member, trade);
+
+        if(likeTrade == null) {
+            throw new IllegalArgumentException("찜하기한 게시글이 아닙니다");
+        }
+
+        trade.decreaseLikeCount();
+        likeTradeRepository.delete(likeTrade);
+    }
+
 
     private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -4,6 +4,7 @@ package com.backend.DuruDuru.global.web.controller;
 import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
 import com.backend.DuruDuru.global.converter.TradeConverter;
+import com.backend.DuruDuru.global.domain.entity.LikeTrade;
 import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.enums.Status;
 import com.backend.DuruDuru.global.domain.enums.TradeType;
@@ -164,30 +165,28 @@ public class TradeController {
     }
 
     // 품앗이 찜하기
-    @PostMapping("/like/{member_id}/{trade_id}")
+    @PostMapping("/like/{trade_id}")
     @Operation(summary = "품앗이 찜하기 API", description = "품앗이 찜하기 API 입니다.")
-    public ApiResponse<?> likeTrade() {
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
+    public ApiResponse<TradeResponseDTO.LikeTradeResultDTO> likeTrade(
+            @RequestParam Long memberId,
+            @PathVariable("trade_id") Long tradeId
+
+    ) {
+        LikeTrade likeTrade = tradeCommandService.createLike(memberId, tradeId);
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, TradeConverter.toLikeTradeResultDTO(likeTrade));
     }
 
     // 품앗이 찜하기 취소
-    @DeleteMapping("/like/delete/{trade_id}")
+    @DeleteMapping("/like/{trade_id}/delete")
     @Operation(summary = "품앗이 찜하기 취소 API", description = "품앗이 찜하기를 취소하는 API 입니다.")
     public ApiResponse<?> deleteLideTrade(){
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
     }
 
     // 특정 품앗이의 찜하기 개수 조회
-    @GetMapping("/like/count/{trade_id}")
+    @GetMapping("/like/{trade_id}/count")
     @Operation(summary = "특정 품앗이의 찜하기 개수 조회 API", description = "특정 품앗이의 찜하기 개수를 조회하는 API 입니다.")
     public ApiResponse<?> findLikeCount(){
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
-    }
-
-    // 품앗이 링크 공유
-    @PostMapping("/shareUrl")
-    @Operation(summary = "품앗이 링크 공유 API", description = "품앗이 링크를 공유하는 API 입니다.")
-    public ApiResponse<?> shareUrl(){
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -179,7 +179,11 @@ public class TradeController {
     // 품앗이 찜하기 취소
     @DeleteMapping("/like/{trade_id}/delete")
     @Operation(summary = "품앗이 찜하기 취소 API", description = "품앗이 찜하기를 취소하는 API 입니다.")
-    public ApiResponse<?> deleteLideTrade(){
+    public ApiResponse<?> deleteLideTrade(
+            @RequestParam Long memberId,
+            @PathVariable("trade_id") Long tradeId
+    ){
+        tradeCommandService.deleteLike(memberId, tradeId);
         return ApiResponse.onSuccess(SuccessStatus.TRADE_OK, null);
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeRequestDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeRequestDTO.java
@@ -37,4 +37,13 @@ public class TradeRequestDTO {
         private List<Long> deleteImgIds;
         private List<MultipartFile> addTradeImgs;
     }
+
+    @Setter
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CreateLikeRequestDTO {
+        private Long memberId;
+        private Long tradeId;
+    }
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
@@ -30,30 +30,10 @@ public class TradeResponseDTO {
         String eupmyeondong;
         Status status;
         TradeType tradeType;
+        Long likeCount;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
         List<TradeImg> tradeImgs;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class UpdateTradeResultDTO {
-        Long tradeId;
-        Long memberId;
-        String nickName;
-        Long ingredientId;
-        Long ingredientCount;
-        LocalDate expiryDate;
-        String title;
-        String body;
-        String eupmyeondong;
-        Status status;
-        TradeType tradeType;
-        LocalDateTime createdAt;
-        LocalDateTime updatedAt;
-        // String[] tradeImgUrls;
     }
 
     @Getter
@@ -70,6 +50,7 @@ public class TradeResponseDTO {
         String eupmyeondong;
         Status status;
         TradeType tradeType;
+        Long likeCount;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
         String thumbnailImgUrl;
@@ -83,5 +64,15 @@ public class TradeResponseDTO {
     public static class TradePreviewListDTO {
         int totalCount;
         List<TradePreviewDTO> tradeList;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LikeTradeResultDTO {
+        Long memberId;
+        Long tradeId;
+        Long likeCount;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #157 

## 📝작업 내용
> - Trade 엔티티에 likeCount 칼럼 추가
> - 찜하기 관련 엔드포인트 수정
> - 품앗이 찜하기 API 구현
> - 품앗이 찜하기 취소 API 구현

## 🔎코드 설명 및 참고 사항
> - 엔드포인트 /trade/like/{trade_id}/**로 수정

> - 품앗이 찜하기 성공
> <img width="214" alt="스크린샷 2025-02-11 오후 1 33 48" src="https://github.com/user-attachments/assets/c2e7395b-a305-4e5b-8766-4f8e4b434751" />

> - 품앗이 찜하기 취소 성공
> <img width="214" alt="스크린샷 2025-02-11 오후 1 34 31" src="https://github.com/user-attachments/assets/a0a08475-aec2-4b09-906e-c86e618c4917" />


## 💬리뷰 요구사항
>
