### PR TITLE
Feat: 식재료 목록 기반 레시피 추천 API

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/config/AppConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.backend.DuruDuru.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/backend/DuruDuru/global/converter/RecipeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/RecipeConverter.java
@@ -7,9 +7,9 @@ public class RecipeConverter {
 
     public static RecipeResponseDTO.RecipeResponse toDetailResponse(Recipe recipe) {
         return RecipeResponseDTO.RecipeResponse.builder()
-                .recipeId(recipe.getRecipeId())
-                .title(recipe.getTitle())
-                .content(recipe.getContent())
+//                .recipeId(recipe.getRecipeId())
+//                .title(recipe.getTitle())
+//                .content(recipe.getContent())
                 .build();
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandService.java
@@ -10,4 +10,5 @@ public interface RecipeCommandService {
     void setRecipeFavorite(Member member, Long recipeId);
     List<RecipeResponseDTO.RecipeResponse> getFavoriteRecipes(Member member);
     RecipeResponseDTO.RecipePageResponse getPopularRecipes(int page, int size);
+    RecipeResponseDTO.RecipePageResponse searchRecipes(String ingredients, int page, int size);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandServiceImpl.java
@@ -12,10 +12,13 @@ import com.backend.DuruDuru.global.repository.RecipeRepository;
 import com.backend.DuruDuru.global.web.dto.Recipe.RecipeResponseDTO;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,6 +30,10 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
     private final RecipeRepository recipeRepository;
     private final MemberRepository memberRepository;
     private final MemberRecipeRepository memberRecipeRepository;
+
+    @Value("${api.foodsafety.keyId}")
+    private String keyId;
+    private final RestTemplate restTemplate;
 
     @Override
     @Transactional
@@ -80,9 +87,9 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
 
         List<RecipeResponseDTO.RecipeResponse> recipeResponses = recipes.stream()
                 .map(recipe -> RecipeResponseDTO.RecipeResponse.builder()
-                        .recipeId(recipe.getRecipeId())
-                        .title(recipe.getTitle())
-                        .content(recipe.getContent())
+                        //.recipeId(recipe.getRecipeId())
+                        //.title(recipe.getTitle())
+                        //.content(recipe.getContent())
                         .build()
                 )
                 .toList();
@@ -94,6 +101,68 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
                 .totalElements(recipes.getTotalElements())
                 .recipes(recipeResponses)
                 .build();
+    }
+
+    // 식재료 기반 레시피 추천
+    @Override
+    public RecipeResponseDTO.RecipePageResponse searchRecipes(String ingredients, int page, int size) {
+        int startIdx = (page - 1) * size + 1;
+        int endIdx = page * size;
+
+        // 전체 항목 개수 계산
+        long totalElements = getTotalElements(ingredients);
+        int totalPages = (int) Math.ceil((double) totalElements / size);
+
+        String url = buildApiUrl(ingredients, startIdx, endIdx);
+
+        RecipeResponseDTO.RecipeApiResponse apiResponse = restTemplate.getForObject(url, RecipeResponseDTO.RecipeApiResponse.class);
+
+        List<RecipeResponseDTO.RecipeResponse> recipes = apiResponse.getRecipes().stream()
+                .map(recipe -> RecipeResponseDTO.RecipeResponse.builder()
+                        .recipeId(recipe.getRcpSeq())
+                        .imageUrl(recipe.getAttFileNoMain())
+                        .build())
+                .collect(Collectors.toList());
+
+        return RecipeResponseDTO.RecipePageResponse.builder()
+                .page(page)
+                .size(size)
+                .totalPages(totalPages)  // 임시값, API에서 제공되는 데이터에 따라 변경 필요
+                .totalElements(totalElements)  // 임시값
+                .recipes(recipes)
+                .build();
+    }
+
+    private long getTotalElements(String ingredients) {
+        int batchSize = 1000;
+        int currentStartIdx = 1;
+        int currentEndIdx = batchSize;
+        long totalCount = 0;
+
+        while (true) {
+            String url = buildApiUrl(ingredients, currentStartIdx, currentEndIdx);
+            RecipeResponseDTO.RecipeApiResponse apiResponse = restTemplate.getForObject(url, RecipeResponseDTO.RecipeApiResponse.class);
+
+            if (apiResponse == null || apiResponse.getRecipes() == null || apiResponse.getRecipes().isEmpty()) {
+                break;  // 데이터가 없으면 루프 종료
+            }
+
+            totalCount += apiResponse.getRecipes().size();
+            if (apiResponse.getRecipes().size() < batchSize) {
+                break;  // 마지막 페이지에 도달한 경우 루프 종료
+            }
+
+            currentStartIdx += batchSize;
+            currentEndIdx += batchSize;
+        }
+
+        return totalCount;
+    }
+    private String buildApiUrl(String ingredients, int startIdx, int endIdx) {
+        return UriComponentsBuilder.fromHttpUrl("http://openapi.foodsafetykorea.go.kr/api")
+                .pathSegment(keyId, "COOKRCP01", "json", String.valueOf(startIdx), String.valueOf(endIdx))
+                .queryParam("RCP_PARTS_DTLS", ingredients)
+                .toUriString();
     }
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/RecipeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/RecipeController.java
@@ -73,24 +73,19 @@ public class RecipeController {
 
     // 식재료 목록 기반 레시피 추천
     @GetMapping("/recommend")
-    @Operation(summary = "식재료 목록 기반 레시피 추천 API", description = "보유하고 있는 식재료 목록을 기반으로 레시피를 추천하는 API입니다")
-    public ApiResponse<?> recommendRecipesByIngredients(){
-        return ApiResponse.onSuccess(SuccessStatus.EXAMPLE_OK, null);
-    }
-
-
-
-
-    // 레시피 공유 (링크, Kakao)
-    @PostMapping("/{recipeId}/share")
     @Parameters({
-            @Parameter(name = "recipeId", description = "공유하려는 레시피 id")
+            @Parameter(name = "ingredients", description = "레시피 추천을 위한 식재료 입니다."),
+            @Parameter(name = "page", description = "페이지 번호, 기본값은 1입니다"),
+            @Parameter(name = "size", description = "페이지 당 항목 수, 기본값은 10입니다.")
     })
-    @Operation(summary = "레시피 공유 API", description = "레시피 공유(링크, Kakao)를 하는 API입니다")
-    public ApiResponse<?> shareRecipes(){
-        return ApiResponse.onSuccess(SuccessStatus.EXAMPLE_OK, null);
+    @Operation(summary = "식재료 목록 기반 레시피 추천 API", description = "보유하고 있는 식재료 목록을 기반으로 레시피를 추천하는 API입니다")
+    public ApiResponse<RecipeResponseDTO.RecipePageResponse> recommendRecipesByIngredients(
+            @RequestParam String ingredients,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        RecipeResponseDTO.RecipePageResponse recipes = recipeService.searchRecipes(ingredients, page, size);
+        return ApiResponse.onSuccess(SuccessStatus.EXAMPLE_OK, recipes);
     }
-
-
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Recipe/RecipeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Recipe/RecipeResponseDTO.java
@@ -1,20 +1,21 @@
 package com.backend.DuruDuru.global.web.dto.Recipe;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.util.List;
 
 public class RecipeResponseDTO {
 
-    @Getter
-    @Builder
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class RecipeResponse {
-        private Long recipeId;
-        private String title;
-        private String content;
-    }
+//    @Getter
+//    @Builder
+//    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+//    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+//    public static class RecipeResponse {
+//        private Long recipeId;
+//        private String title;
+//        private String content;
+//    }
 
     @Getter
     @Builder
@@ -26,5 +27,46 @@ public class RecipeResponseDTO {
         private int totalPages;
         private long totalElements;
         private List<RecipeResponse> recipes;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RecipeResponse {
+        private String recipeId;
+        private String imageUrl;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RecipeApiResponse {
+
+        @JsonProperty("COOKRCP01")
+        private RecipeData data;
+
+        public List<Recipe> getRecipes() {
+            return data != null ? data.getRow() : null;
+        }
+
+        static class RecipeData {
+            private List<Recipe> row;
+
+            public List<Recipe> getRow() {
+                return row;
+            }
+        }
+
+        @Getter
+        public static class Recipe {
+            @JsonProperty("RCP_SEQ")
+            private String rcpSeq;
+
+            @JsonProperty("ATT_FILE_NO_MAIN")
+            private String attFileNoMain;
+
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #156 

## 📝작업 내용
> 식재료 목록 기반 레시피, 식품의약품안전처 공공데이터 활용에서 제공하는 open api를 사용했습니다.
식재료를 요청으로 주면, 해당 재료를 통해 만들 수 있는 레시피 id와 레시피 사진을 반환합니다.
응답 결과는 무한 스크롤로 구현하였습니다

## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
