### PR TITLE
Refactor: 레시피 즐겨찾기 API

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Member.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Member.java
@@ -64,7 +64,7 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Notification> notifications = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberRecipe> memberRecipes = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/MemberRecipe.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/MemberRecipe.java
@@ -21,7 +21,14 @@ public class MemberRecipe extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recipe_id", nullable = false)
-    private Recipe recipe;
+    @Column(name = "recipe_seq", nullable = false , columnDefinition = "varchar(50)")
+    private String recipeSeq;
+
+    public void setMember(Member member) {
+        this.member = member;
+        if (!member.getMemberRecipes().contains(this)) {
+            member.getMemberRecipes().add(this);
+        }
+    }
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/domain/entity/Recipe.java
+++ b/src/main/java/com/backend/DuruDuru/global/domain/entity/Recipe.java
@@ -27,8 +27,5 @@ public class Recipe extends BaseEntity {
     private String content;
 
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberRecipe> memberRecipes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecipeIngredient> recipeIngredients = new ArrayList<>();
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/MemberRecipeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/MemberRecipeRepository.java
@@ -2,12 +2,12 @@ package com.backend.DuruDuru.global.repository;
 
 import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.entity.MemberRecipe;
-import com.backend.DuruDuru.global.domain.entity.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface MemberRecipeRepository extends JpaRepository<MemberRecipe, Long> {
-    MemberRecipe findByMemberAndRecipe(Member member, Recipe recipe);
     List<MemberRecipe> findAllByMember(Member member);
+    boolean existsByMemberAndRecipeSeq(Member member, String recipeSeq);
+    void deleteByMemberAndRecipeSeq(Member member, String recipeSeq);
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/RecipeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/RecipeRepository.java
@@ -7,6 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
-    @Query("SELECT r FROM Recipe r LEFT JOIN r.memberRecipes mr GROUP BY r ORDER BY COUNT(mr) DESC")
-    Page<Recipe> findAllByPopular(Pageable pageable);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandService.java
@@ -7,8 +7,6 @@ import java.util.List;
 
 public interface RecipeCommandService {
     RecipeResponseDTO.RecipeDetailResponse getRecipeDetailById(String recipeId);
-    void setRecipeFavorite(Member member, Long recipeId);
-    List<RecipeResponseDTO.RecipeResponse> getFavoriteRecipes(Member member);
-    RecipeResponseDTO.RecipePageResponse getPopularRecipes(int page, int size);
+    public void setRecipeFavorite(Member member, String recipeSeq);
     RecipeResponseDTO.RecipePageResponse searchRecipes(String ingredients, int page, int size);
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/RecipeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/RecipeController.java
@@ -42,35 +42,37 @@ public class RecipeController {
             @Parameter(name = "recipeId", description = "즐겨찾기를 설정하려는 레시피 id")
     })
     @Operation(summary = "레시피 즐겨찾기 추가/삭제 API", description = "레시피 즐겨찾기를 추가하거나 삭제하는 API입니다")
-    public ApiResponse<?> setRecipeFavorite(@Parameter(name = "user", hidden = true) @AuthUser Member member, @RequestParam Long recipeId){
+    public ApiResponse<?> setRecipeFavorite(
+            @Parameter(name = "user", hidden = true) @AuthUser Member member,
+            @RequestParam String recipeId){
         recipeService.setRecipeFavorite(member, recipeId);
         return ApiResponse.onSuccess(SuccessStatus.RECIPE_FAVORITE_SET_OK, null);
     }
 
 
     // 내가 즐겨찾기 설정한 레시피 목록 확인
-    @GetMapping("/favorite")
-    @Operation(summary = "내가 즐겨찾기 설정한 레시피 목록 확인 API", description = "로그인한 사용자가 즐겨찾기 설정한 레시피 목록을 확인하는 API입니다")
-    public ApiResponse<List<RecipeResponseDTO.RecipeResponse>> getFavoriteRecipes(@Parameter(name = "user", hidden = true) @AuthUser Member member){
-        List<RecipeResponseDTO.RecipeResponse> favorites = recipeService.getFavoriteRecipes(member);
-        return ApiResponse.onSuccess(SuccessStatus.RECIPE_FAVORITE_FETCH_OK, favorites);
-    }
+//    @GetMapping("/favorite")
+//    @Operation(summary = "내가 즐겨찾기 설정한 레시피 목록 확인 API", description = "로그인한 사용자가 즐겨찾기 설정한 레시피 목록을 확인하는 API입니다")
+//    public ApiResponse<List<RecipeResponseDTO.RecipeResponse>> getFavoriteRecipes(@Parameter(name = "user", hidden = true) @AuthUser Member member){
+//        List<RecipeResponseDTO.RecipeResponse> favorites = recipeService.getFavoriteRecipes(member);
+//        return ApiResponse.onSuccess(SuccessStatus.RECIPE_FAVORITE_FETCH_OK, favorites);
+//    }
 
 
     // 즐겨찾기 수가 많은 레시피 추천
-    @GetMapping("/popular")
-    @Parameters({
-            @Parameter(name = "page", description = "페이지 번호, 기본값은 1입니다"),
-            @Parameter(name = "size", description = "페이지 당 항목 수, 기본값은 10입니다.")
-    })
-    @Operation(summary = "즐겨찾기 수가 많은 레시피 추천 API", description = "즐겨찾기 수가 많은 레시피를 추천하는 API입니다")
-    public ApiResponse<RecipeResponseDTO.RecipePageResponse> getPopularRecipes(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
-    ) {
-        RecipeResponseDTO.RecipePageResponse response = recipeService.getPopularRecipes(page, size);
-        return ApiResponse.onSuccess(SuccessStatus.RECIPE_FAVORITE_SORT_OK, response);
-    }
+//    @GetMapping("/popular")
+//    @Parameters({
+//            @Parameter(name = "page", description = "페이지 번호, 기본값은 1입니다"),
+//            @Parameter(name = "size", description = "페이지 당 항목 수, 기본값은 10입니다.")
+//    })
+//    @Operation(summary = "즐겨찾기 수가 많은 레시피 추천 API", description = "즐겨찾기 수가 많은 레시피를 추천하는 API입니다")
+//    public ApiResponse<RecipeResponseDTO.RecipePageResponse> getPopularRecipes(
+//            @RequestParam(defaultValue = "1") int page,
+//            @RequestParam(defaultValue = "10") int size
+//    ) {
+//        RecipeResponseDTO.RecipePageResponse response = recipeService.getPopularRecipes(page, size);
+//        return ApiResponse.onSuccess(SuccessStatus.RECIPE_FAVORITE_SORT_OK, response);
+//    }
 
 
     // 식재료 목록 기반 레시피 추천

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Recipe/RecipeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Recipe/RecipeResponseDTO.java
@@ -26,6 +26,7 @@ public class RecipeResponseDTO {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class RecipeResponse {
         private String recipeId;
+        private String recipeName;
         private String imageUrl;
     }
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #163 

## 📝작업 내용
> 레시피 즐겨찾기 API

open API를 사용하여 해당 API가 제공하는 레시피 일련번호를 저장하도록 수정했습니다.
즐겨찾기가 안되어있는 레시피를 즐겨찾기하면 MemberRecipe에 해당 레시피 일련번호가 삭제되고, 즐겨찾기가 되어있는 레시피를 즐겨찾기할시 DB에서 삭제됩니다.


## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
