### PR TITLE
Refactor/#168 즐겨찾기 수가 많은 레시피 목록 api

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/repository/MemberRecipeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/MemberRecipeRepository.java
@@ -10,4 +10,5 @@ public interface MemberRecipeRepository extends JpaRepository<MemberRecipe, Long
     Page<MemberRecipe> findByMember(Member member, Pageable pageable);
     boolean existsByMemberAndRecipeName(Member member, String recipeName);
     void deleteByMemberAndRecipeName(Member member, String recipeName);
+    long countByRecipeName(String recipeName);
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/MemberRecipeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/MemberRecipeRepository.java
@@ -5,10 +5,16 @@ import com.backend.DuruDuru.global.domain.entity.MemberRecipe;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRecipeRepository extends JpaRepository<MemberRecipe, Long> {
     Page<MemberRecipe> findByMember(Member member, Pageable pageable);
     boolean existsByMemberAndRecipeName(Member member, String recipeName);
     void deleteByMemberAndRecipeName(Member member, String recipeName);
     long countByRecipeName(String recipeName);
+
+    @Query("SELECT r.recipeName, COUNT(r) AS favoriteCount FROM MemberRecipe r " +
+            "GROUP BY r.recipeName " +
+            "ORDER BY favoriteCount DESC")
+    Page<Object[]> findPopularRecipes(Pageable pageable);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandService.java
@@ -10,4 +10,5 @@ public interface RecipeCommandService {
     public void setRecipeFavorite(Member member, String recipeSeq);
     RecipeResponseDTO.RecipePageResponse searchRecipes(String ingredients, int page, int size);
     RecipeResponseDTO.RecipePageResponse getFavoriteRecipes(Member member, int page, int size);
+    RecipeResponseDTO.RecipePageResponse getPopularRecipes(int page, int size);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/RecipeService/RecipeCommandServiceImpl.java
@@ -37,7 +37,6 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
     @Transactional
     public RecipeResponseDTO.RecipeDetailResponse getRecipeDetailByName(String recipeName) {
         String url = buildApiUrl(recipeName);
-        System.out.println("URL : " + url);
         RecipeResponseDTO.RecipeApiResponse apiResponse = restTemplate.getForObject(url, RecipeResponseDTO.RecipeApiResponse.class);
 
         if (apiResponse == null || apiResponse.getRecipes() == null || apiResponse.getRecipes().isEmpty()) {
@@ -48,9 +47,10 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
 
         // 메뉴명 제거 및 재료 정보 콤마로 구분
         String cleanedIngredients = cleanIngredients(recipe.getRcpPartsDtls());
-
         // 만드는 법 단계에서 마지막 알파벳 제거
         List<String> cleanedManualSteps = cleanManualSteps(recipe.getManualSteps());
+
+        long favoriteCount = memberRecipeRepository.countByRecipeName(recipeName);
 
         return RecipeResponseDTO.RecipeDetailResponse.builder()
                 .recipeName(recipe.getRcpNm())
@@ -59,6 +59,7 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
                 .ingredients(cleanedIngredients)
                 .imageUrl(recipe.getAttFileNoMk())
                 .manualSteps(cleanedManualSteps)
+                .favoriteCount(favoriteCount)
                 .build();
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/RecipeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/RecipeController.java
@@ -67,19 +67,19 @@ public class RecipeController {
 
 
     // 즐겨찾기 수가 많은 레시피 추천
-//    @GetMapping("/popular")
-//    @Parameters({
-//            @Parameter(name = "page", description = "페이지 번호, 기본값은 1입니다"),
-//            @Parameter(name = "size", description = "페이지 당 항목 수, 기본값은 10입니다.")
-//    })
-//    @Operation(summary = "즐겨찾기 수가 많은 레시피 추천 API", description = "즐겨찾기 수가 많은 레시피를 추천하는 API입니다")
-//    public ApiResponse<RecipeResponseDTO.RecipePageResponse> getPopularRecipes(
-//            @RequestParam(defaultValue = "1") int page,
-//            @RequestParam(defaultValue = "10") int size
-//    ) {
-//        RecipeResponseDTO.RecipePageResponse response = recipeService.getPopularRecipes(page, size);
-//        return ApiResponse.onSuccess(SuccessStatus.RECIPE_FAVORITE_SORT_OK, response);
-//    }
+    @GetMapping("/popular")
+    @Parameters({
+            @Parameter(name = "page", description = "페이지 번호, 기본값은 1입니다"),
+            @Parameter(name = "size", description = "페이지 당 항목 수, 기본값은 10입니다.")
+    })
+    @Operation(summary = "즐겨찾기 수가 많은 레시피 추천 API", description = "즐겨찾기 수가 많은 레시피를 반환하는 API입니다")
+    public ApiResponse<RecipeResponseDTO.RecipePageResponse> getPopularRecipes(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        RecipeResponseDTO.RecipePageResponse response = recipeService.getPopularRecipes(page, size);
+        return ApiResponse.onSuccess(SuccessStatus.RECIPE_FAVORITE_SORT_OK, response);
+    }
 
 
     // 식재료 목록 기반 레시피 추천

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Recipe/RecipeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Recipe/RecipeResponseDTO.java
@@ -33,13 +33,13 @@ public class RecipeResponseDTO {
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class RecipeDetailResponse {
+        private long favoriteCount; // 즐겨찾기 수
         private String recipeName; // 메뉴명
         private String cookingMethod; // 조리방법
         private String recipeType; // 요리종류
         private String ingredients; // 재료정보
         private String imageUrl; // 이미지 경로(대)
         private List<String> manualSteps; // 만드는 법 단계 목록
-
     }
 
     @Getter

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Recipe/RecipeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Recipe/RecipeResponseDTO.java
@@ -27,6 +27,7 @@ public class RecipeResponseDTO {
     public static class RecipeResponse {
         private String recipeName;
         private String imageUrl;
+        private long favoriteCount;
     }
     @Getter
     @Builder


### PR DESCRIPTION
## #️⃣연관된 이슈
> #168 

## 📝작업 내용
> 즐겨찾기 수가 많은 레시피 목록 API입니다.
즐겨찾기 수가 많은 수대로 정렬하여 레시피를 반환합니다.

응답은 레시피 이름, 레시피 이미지, 즐겨찾기 수 입니다

> 스웨거 결과
<img width="447" alt="image" src="https://github.com/user-attachments/assets/3a2561df-18c3-465a-b77a-02d9df01f77d" />


## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
