### PR TITLE
Refactor: 식재료 소분류 카테고리 조회시 카테고리 이미지도 함께 반환하도록 API 수정

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -119,8 +119,19 @@ public class IngredientController {
     @GetMapping("/category/major-to-minor")
     @Operation(summary = "대분류에 속하는 소분류 카테고리 조회 API", description = "대분류에 속하는 소분류 카테고리를 조회하는 API 입니다.")
     public ApiResponse<?> majorToMinorCategory(@RequestParam MajorCategory majorCategory) {
-        Map<String, Object> category = ingredientQueryService.getMinorCategoriesByMajor(majorCategory);
-        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, category);
+        Map<String, Object> categoryMap = ingredientQueryService.getMinorCategoriesByMajor(majorCategory);
+
+        List<String> minorCategoryNames = (List<String>) categoryMap.get("minorCategoryList");
+        List<MinorCategory> minorCategories = minorCategoryNames.stream()
+                .map(MinorCategory::valueOf)
+                .collect(Collectors.toList());
+        List<IngredientResponseDTO.MinorCategoryDTO> minorCategoryWithImages =
+                IngredientResponseDTO.MinorCategoryDTO.fromMinorCategories(minorCategories);
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("majorCategory", categoryMap.get("majorCategory"));
+        response.put("minorCategoryList", minorCategoryWithImages);
+        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, response);
     }
 
     // 소분류 카테고리 목록 전체 조회

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -123,6 +123,15 @@ public class IngredientController {
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, category);
     }
 
+    // 소분류 카테고리 목록 전체 조회
+    @GetMapping("/minorCategory")
+    @Operation(summary = "소분류 카테고리 목록 전체 조회 API", description = "소분류 카테고리 목록 전체를 조회하는 API 입니다.")
+    public ApiResponse<List<IngredientResponseDTO.MinorCategoryDTO>> minorCategoryList(){
+        List<MinorCategory> categories = Arrays.asList(MinorCategory.values());
+        List<IngredientResponseDTO.MinorCategoryDTO> response = IngredientResponseDTO.MinorCategoryDTO.fromMinorCategories(categories);
+        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, response);
+    }
+
     // 소분류 카테고리에 속하는 식재료 리스트 조회
     @GetMapping("/minorCategory/list")
     @Operation(summary = "소분류 카테고리에 속하는 식재료 리스트 조회 API", description = "소분류 카테고리에 속하는 식재료 리스트 조회하는 API 입니다.")
@@ -141,13 +150,7 @@ public class IngredientController {
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toMajorCategoryIngredientPreviewListDTO(majorCategory, ingredients));
     }
 
-    // 소분류 카테고리 목록 전체 조회
-    @GetMapping("/minorCategory")
-    @Operation(summary = "소분류 카테고리 목록 전체 조회 API", description = "소분류 카테고리 목록 전체를 조회하는 API 입니다.")
-    public ApiResponse<List<MinorCategory>> minorCategoryList(){
-        List<MinorCategory> categories = Arrays.asList(MinorCategory.values());
-        return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, categories);
-    }
+
 
 //    // 소분류 카테고리에 속하는 식재료 개수 조회
 //    @GetMapping("/category/count")

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Ingredient/IngredientResponseDTO.java
@@ -10,6 +10,7 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class IngredientResponseDTO {
 
@@ -200,4 +201,22 @@ public class IngredientResponseDTO {
         Long receiptId;
         LocalDate purchaseDate;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MinorCategoryDTO {
+        private String minorCategory;
+        private String categoryImageUrl;
+
+        private static final String DEFAULT_IMAGE_URL = "https://duruduru.s3.ap-northeast-2.amazonaws.com/76636494-cfa7-4b1b-8649-2eda45f1be8a";
+
+        public static List<MinorCategoryDTO> fromMinorCategories(List<MinorCategory> categories) {
+            return categories.stream()
+                    .map(category -> new MinorCategoryDTO(category.name(), DEFAULT_IMAGE_URL))
+                    .collect(Collectors.toList());
+        }
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #172 

## 📝작업 내용
> - 소분류 카테고리 전체 조회시 카테고리 이미지 함께 반환하도록 수정
<img width="80%" alt="스크린샷 2025-02-11 오후 11 45 05" src="https://github.com/user-attachments/assets/4796b1a8-0f72-4c8f-b3a4-1be9d6b841cf" />

> - 대분류에 따른 소분류 카테고리 조회시 카테고리 이미지 함께 반환하도록 수정
<img width="80%" alt="스크린샷 2025-02-11 오후 11 45 33" src="https://github.com/user-attachments/assets/b31b5869-9c56-4e6d-a42b-36f1825b3f4b" />

## 🔎코드 설명 및 참고 사항
> 

## 💬리뷰 요구사항
>
