### PR TITLE
Refactor: 식재료 카테고리 미설정시 발생하는 조회 오류 예외처리

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -35,19 +35,34 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     @Override
     public List<Ingredient> getAllIngredients(Long memberId) {
         findMemberById(memberId);
-        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(memberId);
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(memberId);
+        validateIngredientCategories(ingredients);
+        return ingredients;
     }
 
     @Override
     public List<Ingredient> getIngredientsNearExpiry(Long memberId) {
         findMemberById(memberId);
-        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayAsc(memberId);
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayAsc(memberId);
+        validateIngredientCategories(ingredients);
+        return ingredients;
     }
 
     @Override
     public List<Ingredient> getIngredientsFarExpiry(Long memberId) {
         findMemberById(memberId);
-        return ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayDesc(memberId);
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayDesc(memberId);
+        validateIngredientCategories(ingredients);
+        return ingredients;
+    }
+
+    // 식재료 카테고리 미설정 예외처리
+    private void validateIngredientCategories(List<Ingredient> ingredients) {
+        for (Ingredient ingredient : ingredients) {
+            if (ingredient.getMajorCategory() == null || ingredient.getMinorCategory() == null) {
+                throw new IllegalStateException("식재료의 카테고리 설정은 필수입니다.");
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #87 

## 📝작업 내용
> 식재료 카테고리 미설정시 발생하는 조회 오류 예외처리

## 🔎코드 설명 및 참고 사항
> 식재료 대분류 또는 소분류 카테고리를 설정하지 않을 경우 발생하는 조회 오류 예외처리

## 💬리뷰 요구사항
>
