### PR TITLE
Refactor: 식재료 조회 관련 API에서 식재료 필수 항목 미설정시 발생하는 오류 예외처리

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -36,7 +36,7 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     public List<Ingredient> getAllIngredients(Long memberId) {
         findMemberById(memberId);
         List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(memberId);
-        validateIngredientCategories(ingredients);
+        validateIngredientProperties(ingredients);
         return ingredients;
     }
 
@@ -44,7 +44,7 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     public List<Ingredient> getIngredientsNearExpiry(Long memberId) {
         findMemberById(memberId);
         List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayAsc(memberId);
-        validateIngredientCategories(ingredients);
+        validateIngredientProperties(ingredients);
         return ingredients;
     }
 
@@ -52,15 +52,18 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     public List<Ingredient> getIngredientsFarExpiry(Long memberId) {
         findMemberById(memberId);
         List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayDesc(memberId);
-        validateIngredientCategories(ingredients);
+        validateIngredientProperties(ingredients);
         return ingredients;
     }
 
-    // 식재료 카테고리 미설정 예외처리
-    private void validateIngredientCategories(List<Ingredient> ingredients) {
+    // 식재료 필수 속성 미설정 예외처리 (카테고리 및 보관방식)
+    private void validateIngredientProperties(List<Ingredient> ingredients) {
         for (Ingredient ingredient : ingredients) {
             if (ingredient.getMajorCategory() == null || ingredient.getMinorCategory() == null) {
                 throw new IllegalStateException("식재료의 카테고리 설정은 필수입니다.");
+            }
+            if (ingredient.getStorageType() == null) {
+                throw new IllegalStateException("식재료의 보관방식 설정은 필수입니다.");
             }
         }
     }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -56,14 +56,20 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
         return ingredients;
     }
 
-    // 식재료 필수 속성 미설정 예외처리 (카테고리 및 보관방식)
+    // 식재료 필수 속성 미설정 예외처리 (카테고리, 보관방식, 구매날짜, 소비기한)
     private void validateIngredientProperties(List<Ingredient> ingredients) {
         for (Ingredient ingredient : ingredients) {
             if (ingredient.getMajorCategory() == null || ingredient.getMinorCategory() == null) {
-                throw new IllegalStateException("식재료의 카테고리 설정은 필수입니다.");
+                throw new IllegalStateException("카테고리 설정이 미완료된 식재료가 존재합니다.");
             }
             if (ingredient.getStorageType() == null) {
-                throw new IllegalStateException("식재료의 보관방식 설정은 필수입니다.");
+                throw new IllegalStateException("보관방식 설정이 미완료된 식재료가 존재합니다.");
+            }
+            if (ingredient.getPurchaseDate() == null) {
+                throw new IllegalStateException("구매날짜 설정이 미완료된 식재료가 존재합니다.");
+            }
+            if (ingredient.getExpiryDate() == null) {
+                throw new IllegalStateException("소비기한 설정이 미완료된 식재료가 존재합니다.");
             }
         }
     }

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryServiceImpl.java
@@ -34,25 +34,52 @@ public class IngredientQueryServiceImpl implements IngredientQueryService {
         return result;
     }
 
-    //소분류 카테고리에 속하는 식재료 조회
+    // 소분류 카테고리에 속하는 식재료 조회
     @Override
     public List<Ingredient> getIngredientsByMinorCategory(Long memberId, MinorCategory minorCategory) {
-        return ingredientRepository.findByMember_MemberIdAndMinorCategory(memberId, minorCategory);
+        List<Ingredient> ingredients = ingredientRepository.findByMember_MemberIdAndMinorCategory(memberId, minorCategory);
+        validateIngredientProperties(ingredients);
+        return ingredients;
     }
 
-    //소분류 카테고리에 속하는 식재료 조회
+    // 대분류 카테고리에 속하는 식재료 조회
     @Override
     public List<Ingredient> getIngredientsByMajorCategory(Long memberId, MajorCategory majorCategory) {
-        return ingredientRepository.findByMember_MemberIdAndMajorCategory(memberId, majorCategory);
+        List<Ingredient> ingredients = ingredientRepository.findByMember_MemberIdAndMajorCategory(memberId, majorCategory);
+        validateIngredientProperties(ingredients);
+        return ingredients;
     }
 
-
+    // 식재료 이름으로 검색
     @Override
     public List<Ingredient> getIngredientsByName(Optional<String> optSearch) {
+        List<Ingredient> ingredients;
         if (optSearch.isPresent()) {
             String search = optSearch.get();
-            return ingredientRepository.findAllByIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(search);
+            ingredients = ingredientRepository.findAllByIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(search);
+        } else {
+            ingredients = ingredientRepository.findAllByOrderByCreatedAtDesc();
         }
-        return ingredientRepository.findAllByOrderByCreatedAtDesc();
+        validateIngredientProperties(ingredients);
+        return ingredients;
     }
+
+    // 식재료 필수 속성 미설정 예외처리 (카테고리, 보관방식, 구매날짜, 소비기한)
+    private void validateIngredientProperties(List<Ingredient> ingredients) {
+        for (Ingredient ingredient : ingredients) {
+            if (ingredient.getMajorCategory() == null || ingredient.getMinorCategory() == null) {
+                throw new IllegalStateException("카테고리 설정이 미완료된 식재료가 존재합니다.");
+            }
+            if (ingredient.getStorageType() == null) {
+                throw new IllegalStateException("보관방식 설정이 미완료된 식재료가 존재합니다.");
+            }
+            if (ingredient.getPurchaseDate() == null) {
+                throw new IllegalStateException("구매날짜 설정이 미완료된 식재료가 존재합니다.");
+            }
+            if (ingredient.getExpiryDate() == null) {
+                throw new IllegalStateException("소비기한 설정이 미완료된 식재료가 존재합니다.");
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #87 

## 📝작업 내용
> 식재료 조회 관련 API에서 식재료 필수 항목 미설정시 발생하는 오류 예외처리

## 🔎코드 설명 및 참고 사항
> 카테고리, 보관방식, 구매날짜, 소비기한 설정이 미왼료 되어있을 경우 식재료 리스트 조회시 예외처리되도록 수정
> OCR을 통한 식재료 등록이 아닌, 직접 등록시 주로 발생하는 오류

## 💬리뷰 요구사항
>
