### PR TITLE
Feat: 대분류 기준 냉장고 식재료 최신 등록순, 소비기한 임박/여유순 조회 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                                 .requestMatchers("/ingredient/search/name", "/ingredient/category/major-to-minor").permitAll()
                                 .requestMatchers("/ingredient/majorCategory/list", "/ingredient/minorCategory/list", "/ingredient/minorCategory/").permitAll()
                                 // Fridge 관련 접근
-                                .requestMatchers("/fridge/{member_id}/all/recent", "/fridge/{member_id}/near-expiry", "/fridge/{member_id}/far-expiry").permitAll()
+                                .requestMatchers("/fridge/all/recent", "/fridge/near-expiry", "/fridge/far-expiry").permitAll()
+                                .requestMatchers("/fridge/majorCategory/all/recent", "/fridge/majorCategory/near-expiry", "/fridge/majorCategory/far-expiry").permitAll()
                                 // OCR 관련 접근
                                 .requestMatchers("/OCR/receipt", "/OCR/ingredient/{ingredient_id}", "/OCR/{receipt_id}/purchase-date").permitAll()
                                 // Town 관련 접근

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -27,4 +27,14 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay DESC")
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayDesc(@Param("memberId") Long memberId);
 
+
+    List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByCreatedAtDesc(Long memberId, MajorCategory majorCategory);
+
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.majorCategory = :majorCategory ORDER BY i.dDay ASC")
+    List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayAsc(Long memberId, MajorCategory majorCategory);
+
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.majorCategory = :majorCategory ORDER BY i.dDay DESC")
+    List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayDesc(Long memberId, MajorCategory majorCategory);
+
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
@@ -1,6 +1,7 @@
 package com.backend.DuruDuru.global.service.FridgeService;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 
 import java.util.List;
 
@@ -9,4 +10,9 @@ public interface FridgeQueryService {
     List<Ingredient> getAllIngredients(Long memberId);
     List<Ingredient> getIngredientsNearExpiry(Long memberId);
     List<Ingredient> getIngredientsFarExpiry(Long memberId);
+
+    List<Ingredient> getAllMajorCategoryIngredients(Long memberId, MajorCategory majorCategory);
+    List<Ingredient> getMajorCategoryIngredientsNearExpiry(Long memberId, MajorCategory majorCategory);
+    List<Ingredient> getMajorCategoryIngredientsFarExpiry(Long memberId, MajorCategory majorCategory);
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.backend.DuruDuru.global.service.FridgeService;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.domain.entity.Member;
+import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.repository.FridgeRepository;
 import com.backend.DuruDuru.global.repository.IngredientRepository;
 import com.backend.DuruDuru.global.repository.MemberRepository;
@@ -11,11 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -56,6 +54,28 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
         validateIngredientProperties(ingredients);
         return ingredients;
     }
+
+    @Override
+    public List<Ingredient> getAllMajorCategoryIngredients(Long memberId, MajorCategory majorCategory) {
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndMajorCategoryOrderByCreatedAtDesc(memberId, majorCategory);
+        validateIngredientProperties(ingredients);
+        return ingredients;
+    }
+
+    @Override
+    public List<Ingredient> getMajorCategoryIngredientsNearExpiry(Long memberId, MajorCategory majorCategory) {
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayAsc(memberId, majorCategory);
+        validateIngredientProperties(ingredients);
+        return ingredients;
+    }
+
+    @Override
+    public List<Ingredient> getMajorCategoryIngredientsFarExpiry(Long memberId, MajorCategory majorCategory) {
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayDesc(memberId, majorCategory);
+        validateIngredientProperties(ingredients);
+        return ingredients;
+    }
+
 
     // 식재료 필수 속성 미설정 예외처리 (카테고리, 보관방식, 구매날짜, 소비기한)
     private void validateIngredientProperties(List<Ingredient> ingredients) {

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -3,6 +3,7 @@ package com.backend.DuruDuru.global.web.controller;
 import com.backend.DuruDuru.global.converter.FridgeConverter;
 import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.service.FridgeService.FridgeQueryService;
 import com.backend.DuruDuru.global.web.dto.Fridge.FridgeResponseDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
@@ -29,26 +30,50 @@ public class FridgeController {
     private final FridgeQueryService fridgeQueryService;
 
     // 전체 식재료 리스트 조회 (최신 등록순)
-    @GetMapping("/{member_id}/all/recent")
+    @GetMapping("/all/recent")
     @Operation(summary = "최신 등록된 순으로 전체 식재료 리스트 조회 API", description = "사용자의 냉장고에 최신 등록된 순으로 전체 식재료 리스트를 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentIngredients(@PathVariable("member_id") Long memberId) {
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentIngredients(@RequestParam Long memberId) {
         List<Ingredient> ingredients = fridgeQueryService.getAllIngredients(memberId);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 소비기한 임박순 식재료 리스트 조회
-    @GetMapping("/{member_id}/near-expiry")
+    @GetMapping("/near-expiry")
     @Operation(summary = "식재료 소비기한 임박순 리스트 조회 API", description = "식재료 리스트를 소비기한이 임박한 순서대로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientNearExpiry(@PathVariable("member_id") Long memberId) {
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientsNearExpiry(@RequestParam Long memberId) {
         List<Ingredient> ingredients = fridgeQueryService.getIngredientsNearExpiry(memberId);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 소비기한 여유순 식재료 리스트 조회
-    @GetMapping("/{member_id}/far-expiry")
+    @GetMapping("/far-expiry")
     @Operation(summary = "식재료 소비기한 여유순 리스트 조회 API", description = "식재료 리스트를 소비기한이 여유로운 순서대로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientFarExpiry(@PathVariable("member_id") Long memberId) {
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientsFarExpiry(@RequestParam Long memberId) {
         List<Ingredient> ingredients = fridgeQueryService.getIngredientsFarExpiry(memberId);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
+    }
+
+    // 대분류 기준 식재료 최신 등록순 리스트 조회
+    @GetMapping("/majorCategory/all/recent")
+    @Operation(summary = "대분류 기준 식재료 최신 등록순 리스트 조회 API", description = "대분류 기준 사용자의 냉장고에 최신 등록된 순으로 전체 식재료 리스트를 조회하는 API 입니다.")
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentMajorCategoryIngredients(@RequestParam Long memberId, @RequestParam MajorCategory majorCategory) {
+        List<Ingredient> ingredients = fridgeQueryService.getAllMajorCategoryIngredients(memberId, majorCategory);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
+    }
+
+    // 대분류 기준 식재료 소비기한 임박순 리스트 조회
+    @GetMapping("/majorCategory/near-expiry")
+    @Operation(summary = "대분류 기준 식재료 소비기한 임박순 리스트 조회 API", description = "대분류 기준 식재료 리스트를 소비기한이 임박한 순서대로 조회하는 API 입니다.")
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> majorCategoryIngredientsNearExpiry(@RequestParam Long memberId, @RequestParam MajorCategory majorCategory) {
+        List<Ingredient> ingredients = fridgeQueryService.getMajorCategoryIngredientsNearExpiry(memberId, majorCategory);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
+    }
+
+    // 대분류 기준 식재료 소비기한 여유순 리스트 조회
+    @GetMapping("/majorCategory/far-expiry")
+    @Operation(summary = "대분류 기준 식재료 소비기한 여유순 리스트 조회 API", description = "대분류 기준 식재료 리스트를 소비기한이 여유로운 순서대로 조회하는 API 입니다.")
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> majorCategoryIngredientsFarExpiry(@RequestParam Long memberId, @RequestParam MajorCategory majorCategory) {
+        List<Ingredient> ingredients = fridgeQueryService.getMajorCategoryIngredientsFarExpiry(memberId, majorCategory);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #100 

## 📝작업 내용
> - 대분류 기준 식재료 최신 등록순 리스트 조회 
> - 대분류 기준 소비기한 임박순 식재료 리스트 조회
> - 대분류 기준 소비기한 여유순 식재료 리스트 조회

## 🔎코드 설명 및 참고 사항
> 대분류 기준 냉장고 식재료 최신 등록순, 소비기한 임박/여유순 조회 API 구현

## 💬리뷰 요구사항
>
