### PR TITLE
Feat: 식재료 이름으로 검색하여 최신 등록순, 소비기한 임박/여유순으로 조회 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
@@ -47,8 +47,9 @@ public class SecurityConfig {
                                 .requestMatchers("/ingredient/search/name", "/ingredient/category/major-to-minor").permitAll()
                                 .requestMatchers("/ingredient/majorCategory/list", "/ingredient/minorCategory/list", "/ingredient/minorCategory/").permitAll()
                                 // Fridge 관련 접근
-                                .requestMatchers("/fridge/all/recent", "/fridge/near-expiry", "/fridge/far-expiry").permitAll()
-                                .requestMatchers("/fridge/majorCategory/all/recent", "/fridge/majorCategory/near-expiry", "/fridge/majorCategory/far-expiry").permitAll()
+                                .requestMatchers("/fridge/recent", "/fridge/near-expiry", "/fridge/far-expiry").permitAll()
+                                .requestMatchers("/fridge/majorCategory/recent", "/fridge/majorCategory/near-expiry", "/fridge/majorCategory/far-expiry").permitAll()
+                                .requestMatchers("/fridge/name/recent", "/fridge/name/near-expiry", "/fridge/name/far-expiry").permitAll()
                                 // OCR 관련 접근
                                 .requestMatchers("/OCR/receipt", "/OCR/ingredient/{ingredient_id}", "/OCR/{receipt_id}/purchase-date").permitAll()
                                 // Town 관련 접근

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -43,4 +43,9 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     // 사용자가 식재료 검색어가 포함된 식재료 소비기한 임박순 조회
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.ingredientName LIKE %:search% ORDER BY i.dDay ASC")
     List<Ingredient> findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayAsc(Long memberId, String search);
+    // 사용자가 식재료 검색어가 포함된 식재료 소비기한 여유순 조회
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.ingredientName LIKE %:search% ORDER BY i.dDay DESC")
+    List<Ingredient> findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayDesc(Long memberId, String search);
+
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -40,5 +40,7 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
     // 사용자가 식재료 검색어가 포함된 식재료 조회 (대소문자 무시)
     List<Ingredient> findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(Long memberId, String search);
-
+    // 사용자가 식재료 검색어가 포함된 식재료 소비기한 임박순 조회
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.ingredientName LIKE %:search% ORDER BY i.dDay ASC")
+    List<Ingredient> findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayAsc(Long memberId, String search);
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -13,26 +13,27 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
     List<Ingredient> findByMember_MemberIdAndMinorCategory(Long memberId, MinorCategory minorCategory);
     List<Ingredient> findByMember_MemberIdAndMajorCategory(Long memberId, MajorCategory majorCategory);
-    List<Ingredient> findAllByIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(String search);
-    List<Ingredient> findAllByOrderByCreatedAtDesc();
+    // 사용자가 등록한 식재료 중 검색어가 포함된 식재료 조회 (대소문자 무시)
+    List<Ingredient> findAllByMember_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(Long memberId, String search);
+    // 사용자가 등록한 모든 식재료 최신순 조회
+    List<Ingredient> findAllByMember_MemberIdOrderByCreatedAtDesc(Long memberId);
 
 
-
-    // 냉장고 관련 메서드
+    // -- 냉장고 관련 -- //
+    // 사용자 식재료 최신순 조회
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(Long memberId);
-
+    // 사용자 식재료 소비기한 임박순 조회
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay ASC")
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayAsc(@Param("memberId") Long memberId);
-
+    // 사용자 식재료 소비기한 여유순 조회
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay DESC")
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayDesc(@Param("memberId") Long memberId);
-
-
+    // 사용자 식재료 대분류 기준 최신순 조회
     List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByCreatedAtDesc(Long memberId, MajorCategory majorCategory);
-
+    // 사용자 식재료 대분류 기준 소비기한 임박순 조회
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.majorCategory = :majorCategory ORDER BY i.dDay ASC")
     List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayAsc(Long memberId, MajorCategory majorCategory);
-
+    // 사용자 식재료 대분류 기준 소비기한 여유순 조회
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.majorCategory = :majorCategory ORDER BY i.dDay DESC")
     List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayDesc(Long memberId, MajorCategory majorCategory);
 

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -28,6 +28,7 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     // 사용자 식재료 소비기한 여유순 조회
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay DESC")
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayDesc(@Param("memberId") Long memberId);
+
     // 사용자 식재료 대분류 기준 최신순 조회
     List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByCreatedAtDesc(Long memberId, MajorCategory majorCategory);
     // 사용자 식재료 대분류 기준 소비기한 임박순 조회
@@ -37,5 +38,7 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.majorCategory = :majorCategory ORDER BY i.dDay DESC")
     List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayDesc(Long memberId, MajorCategory majorCategory);
 
+    // 사용자가 식재료 검색어가 포함된 식재료 조회 (대소문자 무시)
+    List<Ingredient> findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(Long memberId, String search);
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
@@ -18,4 +18,5 @@ public interface FridgeQueryService {
 
     List<Ingredient> getIngredientsByNameRecent(Long memberId, Optional<String> optSearch);
     List<Ingredient> getIngredientsByNameNearExpiry(Long memberId, Optional<String> optSearch);
+    List<Ingredient> getIngredientsByNameFarExpiry(Long memberId, Optional<String> optSearch);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
@@ -17,4 +17,5 @@ public interface FridgeQueryService {
     List<Ingredient> getMajorCategoryIngredientsFarExpiry(Long memberId, MajorCategory majorCategory);
 
     List<Ingredient> getIngredientsByNameRecent(Long memberId, Optional<String> optSearch);
+    List<Ingredient> getIngredientsByNameNearExpiry(Long memberId, Optional<String> optSearch);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
@@ -4,6 +4,7 @@ import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FridgeQueryService {
 
@@ -15,4 +16,5 @@ public interface FridgeQueryService {
     List<Ingredient> getMajorCategoryIngredientsNearExpiry(Long memberId, MajorCategory majorCategory);
     List<Ingredient> getMajorCategoryIngredientsFarExpiry(Long memberId, MajorCategory majorCategory);
 
+    List<Ingredient> getIngredientsByNameRecent(Long memberId, Optional<String> optSearch);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -72,6 +73,20 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     @Override
     public List<Ingredient> getMajorCategoryIngredientsFarExpiry(Long memberId, MajorCategory majorCategory) {
         List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayDesc(memberId, majorCategory);
+        validateIngredientProperties(ingredients);
+        return ingredients;
+    }
+
+    @Override
+    public List<Ingredient> getIngredientsByNameRecent(Long memberId, Optional<String> optSearch) {
+        findMemberById(memberId);
+        List<Ingredient> ingredients;
+        if (optSearch.isPresent() && !optSearch.get().trim().isEmpty()) {
+            String search = optSearch.get();
+            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(memberId, search);
+        } else {
+            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(memberId);
+        }
         validateIngredientProperties(ingredients);
         return ingredients;
     }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -105,6 +105,20 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
         return ingredients;
     }
 
+    @Override
+    public List<Ingredient> getIngredientsByNameFarExpiry(Long memberId, Optional<String> optSearch) {
+        findMemberById(memberId);
+        List<Ingredient> ingredients;
+        if (optSearch.isPresent() && !optSearch.get().trim().isEmpty()) {
+            String search = optSearch.get();
+            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayDesc(memberId, search);
+        } else {
+            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayDesc(memberId);
+        }
+        validateIngredientProperties(ingredients);
+        return ingredients;
+    }
+
 
     // 식재료 필수 속성 미설정 예외처리 (카테고리, 보관방식, 구매날짜, 소비기한)
     private void validateIngredientProperties(List<Ingredient> ingredients) {

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -91,6 +91,20 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
         return ingredients;
     }
 
+    @Override
+    public List<Ingredient> getIngredientsByNameNearExpiry(Long memberId, Optional<String> optSearch) {
+        findMemberById(memberId);
+        List<Ingredient> ingredients;
+        if (optSearch.isPresent() && !optSearch.get().trim().isEmpty()) {
+            String search = optSearch.get();
+            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayAsc(memberId, search);
+        } else {
+            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayAsc(memberId);
+        }
+        validateIngredientProperties(ingredients);
+        return ingredients;
+    }
+
 
     // 식재료 필수 속성 미설정 예외처리 (카테고리, 보관방식, 구매날짜, 소비기한)
     private void validateIngredientProperties(List<Ingredient> ingredients) {

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryService.java
@@ -12,5 +12,5 @@ public interface IngredientQueryService {
     Map<String, Object> getMinorCategoriesByMajor(MajorCategory majorCategory);
     List<Ingredient> getIngredientsByMinorCategory(Long memberId, MinorCategory minorCategory);
     List<Ingredient> getIngredientsByMajorCategory(Long memberId, MajorCategory majorCategory);
-    List<Ingredient> getIngredientsByName(Optional<String> optSearch);
+    List<Ingredient> getIngredientsByName(Long memberId, Optional<String> optSearch);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryServiceImpl.java
@@ -4,9 +4,11 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 import com.backend.DuruDuru.global.repository.IngredientRepository;
+import com.backend.DuruDuru.global.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class IngredientQueryServiceImpl implements IngredientQueryService {
     private final IngredientRepository ingredientRepository;
+    private final MemberRepository memberRepository;
+
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found. ID: " + memberId));
+    }
 
     @Override
     public Map<String, Object> getMinorCategoriesByMajor(MajorCategory majorCategory) {
@@ -52,13 +61,14 @@ public class IngredientQueryServiceImpl implements IngredientQueryService {
 
     // 식재료 이름으로 검색
     @Override
-    public List<Ingredient> getIngredientsByName(Optional<String> optSearch) {
+    public List<Ingredient> getIngredientsByName(Long memberId, Optional<String> optSearch) {
+        findMemberById(memberId);
         List<Ingredient> ingredients;
-        if (optSearch.isPresent()) {
+        if (optSearch.isPresent() && !optSearch.get().trim().isEmpty()) {
             String search = optSearch.get();
-            ingredients = ingredientRepository.findAllByIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(search);
+            ingredients = ingredientRepository.findAllByMember_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(memberId, search);
         } else {
-            ingredients = ingredientRepository.findAllByOrderByCreatedAtDesc();
+            ingredients = ingredientRepository.findAllByMember_MemberIdOrderByCreatedAtDesc(memberId);
         }
         validateIngredientProperties(ingredients);
         return ingredients;

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -90,9 +90,8 @@ public class FridgeController {
     @GetMapping("/name/near-expiry")
     @Operation(summary = "식재료 이름으로 검색 (소비기한 임박순) API", description = "식재료 이름으로 검색하여 소비기한이 임박한 순으로 조회하는 API 입니다.")
     public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameNearExpiry(@RequestParam Long memberId, @RequestParam Optional<String> search) {
-        //List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameNearExpiry(memberId, search);
-        //return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
-        return null;
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameNearExpiry(memberId, search);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 식재료 이름으로 검색 (소비기한 여유순)

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -30,7 +30,7 @@ public class FridgeController {
     private final FridgeQueryService fridgeQueryService;
 
     // 전체 식재료 리스트 조회 (최신 등록순)
-    @GetMapping("/all/recent")
+    @GetMapping("/recent")
     @Operation(summary = "최신 등록된 순으로 전체 식재료 리스트 조회 API", description = "사용자의 냉장고에 최신 등록된 순으로 전체 식재료 리스트를 조회하는 API 입니다.")
     public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentIngredients(@RequestParam Long memberId) {
         List<Ingredient> ingredients = fridgeQueryService.getAllIngredients(memberId);
@@ -54,7 +54,7 @@ public class FridgeController {
     }
 
     // 대분류 기준 식재료 최신 등록순 리스트 조회
-    @GetMapping("/majorCategory/all/recent")
+    @GetMapping("/majorCategor/recent")
     @Operation(summary = "대분류 기준 식재료 최신 등록순 리스트 조회 API", description = "대분류 기준 사용자의 냉장고에 최신 등록된 순으로 전체 식재료 리스트를 조회하는 API 입니다.")
     public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentMajorCategoryIngredients(@RequestParam Long memberId, @RequestParam MajorCategory majorCategory) {
         List<Ingredient> ingredients = fridgeQueryService.getAllMajorCategoryIngredients(memberId, majorCategory);
@@ -77,11 +77,26 @@ public class FridgeController {
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
-//    // 식재료 남은 일 수 조회 (5일 이내)
-//    @GetMapping("/{member_id}/days-left")
-//    @Operation(summary = "식재료 남은 일 수(5일 이내) 조회 API", description = "소비기한이 5일 이내로 남은 식재료의 남은 일 수를 조회하는 API 입니다.")
-//    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientLeftDays(@PathVariable("member_id") Long memberId) {
-//        List<Ingredient> ingredients = fridgeQueryService.getIngredientsD_day(memberId);
-//        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, null);
-//    }
+    // 식재료 이름으로 검색 (최신 등록순)
+    @GetMapping("/name/recent")
+    @Operation(summary = "식재료 이름으로 검색 (최신 등록순) API", description = "식재료 이름으로 검색하여 최신 등록된 순으로 조회하는 API 입니다.")
+    public ApiResponse<?> findByNameRecent() {
+        return null;
+    }
+
+    // 식재료 이름으로 검색 (소비기한 임박순)
+    @GetMapping("/name/near-expiry")
+    @Operation(summary = "식재료 이름으로 검색 (소비기한 임박순) API", description = "식재료 이름으로 검색하여 소비기한이 임박한 순으로 조회하는 API 입니다.")
+    public ApiResponse<?> findByNameNearExpiry() {
+        return null;
+    }
+
+    // 식재료 이름으로 검색 (소비기한 여유순)
+    @GetMapping("/name/far-expiry")
+    @Operation(summary = "식재료 이름으로 검색 (소비기한 여유순) API", description = "식재료 이름으로 검색하여 소비기한이 여유로운 순으로 조회하는 API 입니다.")
+    public ApiResponse<?> findByNameFarExpiry() {
+        return null;
+    }
+
+
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -17,6 +17,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -80,21 +81,26 @@ public class FridgeController {
     // 식재료 이름으로 검색 (최신 등록순)
     @GetMapping("/name/recent")
     @Operation(summary = "식재료 이름으로 검색 (최신 등록순) API", description = "식재료 이름으로 검색하여 최신 등록된 순으로 조회하는 API 입니다.")
-    public ApiResponse<?> findByNameRecent() {
-        return null;
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameRecent(@RequestParam Long memberId, @RequestParam Optional<String> search) {
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameRecent(memberId, search);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 식재료 이름으로 검색 (소비기한 임박순)
     @GetMapping("/name/near-expiry")
     @Operation(summary = "식재료 이름으로 검색 (소비기한 임박순) API", description = "식재료 이름으로 검색하여 소비기한이 임박한 순으로 조회하는 API 입니다.")
-    public ApiResponse<?> findByNameNearExpiry() {
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameNearExpiry(@RequestParam Long memberId, @RequestParam Optional<String> search) {
+        //List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameNearExpiry(memberId, search);
+        //return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
         return null;
     }
 
     // 식재료 이름으로 검색 (소비기한 여유순)
     @GetMapping("/name/far-expiry")
     @Operation(summary = "식재료 이름으로 검색 (소비기한 여유순) API", description = "식재료 이름으로 검색하여 소비기한이 여유로운 순으로 조회하는 API 입니다.")
-    public ApiResponse<?> findByNameFarExpiry() {
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameFarExpiry(@RequestParam Long memberId, @RequestParam Optional<String> search) {
+        //List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameFarExpiry(memberId, search);
+        //return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
         return null;
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -98,9 +98,8 @@ public class FridgeController {
     @GetMapping("/name/far-expiry")
     @Operation(summary = "식재료 이름으로 검색 (소비기한 여유순) API", description = "식재료 이름으로 검색하여 소비기한이 여유로운 순으로 조회하는 API 입니다.")
     public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameFarExpiry(@RequestParam Long memberId, @RequestParam Optional<String> search) {
-        //List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameFarExpiry(memberId, search);
-        //return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
-        return null;
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameFarExpiry(memberId, search);
+        return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -163,7 +163,6 @@ public class IngredientController {
     }
 
 
-
 //    // 소분류 카테고리에 속하는 식재료 개수 조회
 //    @GetMapping("/category/count")
 //    @Operation(summary = "식재료 카테고리 개수 조회 API", description = "식재료 카테고리의 개수를 조회하는 API 입니다. 소분류 카테고리별 식재료 개수를 반환합니다.")

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -110,9 +110,9 @@ public class IngredientController {
 
     // 식재료 이름으로 검색
     @GetMapping("/search/name")
-    @Operation(summary = "식재료 이름으로 검색 API", description = "식재료를 이름으로 검색하는 API 입니다. 입력된 키워드가 포함된 식재료를 모두 반환합니다.")
-    public ApiResponse<IngredientResponseDTO.IngredientDetailListDTO> searchIngredientByName(@RequestParam Optional<String> search){
-        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByName(Optional.of(search.orElse("")));
+    @Operation(summary = "식재료 이름으로 검색 API", description = "식재료를 이름으로 검색하는 API 입니다. 입력된 키워드가 포함된 식재료를 모두 반환하며, 검색어가 없을 경우 전체 식재료 등록순으로 반환합니다.")
+    public ApiResponse<IngredientResponseDTO.IngredientDetailListDTO> searchIngredientByName(@RequestParam Long memberId, @RequestParam Optional<String> search){
+        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByName(memberId, Optional.of(search.orElse("")));
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toIngredientDetailListDTO(ingredients));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #100

## 📝작업 내용
> - 사용자의 냉장고에서 식재료 이름으로 검색하여 최신 등록순으로 조회
> - 사용자의 냉장고에서 식재료 이름으로 검색하여 소비기한 임박/여유순으로 조회 API 구현

## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
