### PR TITLE
Refactor: 냉장고 관련 API 인증 방식을 AuthUser 기반으로 변경

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/DuruDuru/global/apiPayload/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_INVALID_CODE(HttpStatus.UNAUTHORIZED, "AUTH_008", "코드가 유효하지 않습니다."),
     INVALID_KAKAO_REQUEST_INFO(HttpStatus.UNAUTHORIZED, "AUTH_009", "카카오 정보 불러오기에 실패하였습니다."),
     INVALID_NAVER_REQUEST_INFO(HttpStatus.UNAUTHORIZED, "AUTH_010", "네이버 정보 불러오기에 실패하였습니다."),
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH_011", "로그인이 필요합니다."),
 
 
 

--- a/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/DuruDuru/global/config/SecurityConfig.java
@@ -42,9 +42,9 @@ public class SecurityConfig {
                                 .requestMatchers("trade/like/{trade_id}", "/trade/like/{trade_id}/delete", "/trade/like/{trade_id}/count").permitAll()
                                 .requestMatchers("trade/other-trade", "/trade/keyword/alert").permitAll()
                                 // Ingredient 관련 접근
-                                .requestMatchers("/ingredient/{ingredient_id}/photo","/ingredient/{ingredient_id}/purchase-date", "/ingredient/{ingredient_id}/expiry-date","/ingredient/").permitAll()
+                                .requestMatchers("/ingredient/","/ingredient/{ingredient_id}/purchase-date", "/ingredient/{ingredient_id}/expiry-date").permitAll()
                                 .requestMatchers("/ingredient/{ingredient_id}","/ingredient/{ingredient_id}/category", "/ingredient/{ingredient_id}/storage-type").permitAll()
-                                .requestMatchers("/ingredient/search/name", "/ingredient/category/major-to-minor").permitAll()
+                                .requestMatchers("/ingredient/{ingredient_id}/photo","/ingredient/search/name", "/ingredient/category/major-to-minor").permitAll()
                                 .requestMatchers("/ingredient/majorCategory/list", "/ingredient/minorCategory/list", "/ingredient/minorCategory/").permitAll()
                                 // Fridge 관련 접근
                                 .requestMatchers("/fridge/recent", "/fridge/near-expiry", "/fridge/far-expiry").permitAll()

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -24,29 +24,29 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     // 사용자 식재료 최신순 조회
     List<Ingredient> findAllByFridge_MemberOrderByCreatedAtDesc(Member member);
     // 사용자 식재료 소비기한 임박순 조회
-    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay ASC")
-    List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayAsc(@Param("memberId") Long memberId);
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member = :member ORDER BY i.dDay ASC")
+    List<Ingredient> findAllByFridge_MemberOrderByDDayAsc(@Param("member") Member member);
     // 사용자 식재료 소비기한 여유순 조회
-    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay DESC")
-    List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayDesc(@Param("memberId") Long memberId);
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member = :member ORDER BY i.dDay DESC")
+    List<Ingredient> findAllByFridge_MemberOrderByDDayDesc(@Param("member") Member member);
 
     // 사용자 식재료 대분류 기준 최신순 조회
-    List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByCreatedAtDesc(Long memberId, MajorCategory majorCategory);
+    List<Ingredient> findAllByFridge_MemberAndMajorCategoryOrderByCreatedAtDesc(Member member, MajorCategory majorCategory);
     // 사용자 식재료 대분류 기준 소비기한 임박순 조회
-    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.majorCategory = :majorCategory ORDER BY i.dDay ASC")
-    List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayAsc(Long memberId, MajorCategory majorCategory);
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member = :member AND i.majorCategory = :majorCategory ORDER BY i.dDay ASC")
+    List<Ingredient> findAllByFridge_MemberAndMajorCategoryOrderByDDayAsc(Member member, MajorCategory majorCategory);
     // 사용자 식재료 대분류 기준 소비기한 여유순 조회
-    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.majorCategory = :majorCategory ORDER BY i.dDay DESC")
-    List<Ingredient> findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayDesc(Long memberId, MajorCategory majorCategory);
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member = :member AND i.majorCategory = :majorCategory ORDER BY i.dDay DESC")
+    List<Ingredient> findAllByFridge_MemberAndMajorCategoryOrderByDDayDesc(Member member, MajorCategory majorCategory);
 
     // 사용자가 식재료 검색어가 포함된 식재료 조회 (대소문자 무시)
-    List<Ingredient> findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(Long memberId, String search);
+    List<Ingredient> findAllByFridge_MemberAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(Member member, String search);
     // 사용자가 식재료 검색어가 포함된 식재료 소비기한 임박순 조회
-    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.ingredientName LIKE %:search% ORDER BY i.dDay ASC")
-    List<Ingredient> findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayAsc(Long memberId, String search);
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member = :member AND i.ingredientName LIKE %:search% ORDER BY i.dDay ASC")
+    List<Ingredient> findAllByFridge_MemberAndIngredientNameContainingIgnoreCaseOrderByDDayAsc(Member member, String search);
     // 사용자가 식재료 검색어가 포함된 식재료 소비기한 여유순 조회
-    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId AND i.ingredientName LIKE %:search% ORDER BY i.dDay DESC")
-    List<Ingredient> findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayDesc(Long memberId, String search);
+    @Query("SELECT i FROM Ingredient i WHERE i.fridge.member = :member AND i.ingredientName LIKE %:search% ORDER BY i.dDay DESC")
+    List<Ingredient> findAllByFridge_MemberAndIngredientNameContainingIgnoreCaseOrderByDDayDesc(Member member, String search);
 
 
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -1,6 +1,7 @@
 package com.backend.DuruDuru.global.repository;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,7 +22,7 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
     // -- 냉장고 관련 -- //
     // 사용자 식재료 최신순 조회
-    List<Ingredient> findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(Long memberId);
+    List<Ingredient> findAllByFridge_MemberOrderByCreatedAtDesc(Member member);
     // 사용자 식재료 소비기한 임박순 조회
     @Query("SELECT i FROM Ingredient i WHERE i.fridge.member.memberId = :memberId ORDER BY i.dDay ASC")
     List<Ingredient> findAllByFridge_Member_MemberIdOrderByDDayAsc(@Param("memberId") Long memberId);

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
@@ -1,6 +1,7 @@
 package com.backend.DuruDuru.global.service.FridgeService;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 
 import java.util.List;
@@ -8,7 +9,7 @@ import java.util.Optional;
 
 public interface FridgeQueryService {
 
-    List<Ingredient> getAllIngredients(Long memberId);
+    List<Ingredient> getAllIngredients(Member member);
     List<Ingredient> getIngredientsNearExpiry(Long memberId);
     List<Ingredient> getIngredientsFarExpiry(Long memberId);
 

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryService.java
@@ -10,14 +10,14 @@ import java.util.Optional;
 public interface FridgeQueryService {
 
     List<Ingredient> getAllIngredients(Member member);
-    List<Ingredient> getIngredientsNearExpiry(Long memberId);
-    List<Ingredient> getIngredientsFarExpiry(Long memberId);
+    List<Ingredient> getIngredientsNearExpiry(Member member);
+    List<Ingredient> getIngredientsFarExpiry(Member member);
 
-    List<Ingredient> getAllMajorCategoryIngredients(Long memberId, MajorCategory majorCategory);
-    List<Ingredient> getMajorCategoryIngredientsNearExpiry(Long memberId, MajorCategory majorCategory);
-    List<Ingredient> getMajorCategoryIngredientsFarExpiry(Long memberId, MajorCategory majorCategory);
+    List<Ingredient> getAllMajorCategoryIngredients(Member member, MajorCategory majorCategory);
+    List<Ingredient> getMajorCategoryIngredientsNearExpiry(Member member, MajorCategory majorCategory);
+    List<Ingredient> getMajorCategoryIngredientsFarExpiry(Member member, MajorCategory majorCategory);
 
-    List<Ingredient> getIngredientsByNameRecent(Long memberId, Optional<String> optSearch);
-    List<Ingredient> getIngredientsByNameNearExpiry(Long memberId, Optional<String> optSearch);
-    List<Ingredient> getIngredientsByNameFarExpiry(Long memberId, Optional<String> optSearch);
+    List<Ingredient> getIngredientsByNameRecent(Member member, Optional<String> optSearch);
+    List<Ingredient> getIngredientsByNameNearExpiry(Member member, Optional<String> optSearch);
+    List<Ingredient> getIngredientsByNameFarExpiry(Member member, Optional<String> optSearch);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -44,79 +44,87 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     }
 
     @Override
-    public List<Ingredient> getIngredientsNearExpiry(Long memberId) {
-        findMemberById(memberId);
-        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayAsc(memberId);
+    public List<Ingredient> getIngredientsNearExpiry(Member member) {
+        validateLoggedInMember(member);
+        findMemberById(member.getMemberId());
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_MemberOrderByDDayAsc(member);
         validateIngredientProperties(ingredients);
         return ingredients;
     }
 
     @Override
-    public List<Ingredient> getIngredientsFarExpiry(Long memberId) {
-        findMemberById(memberId);
-        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayDesc(memberId);
+    public List<Ingredient> getIngredientsFarExpiry(Member member) {
+        validateLoggedInMember(member);
+        findMemberById(member.getMemberId());
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_MemberOrderByDDayDesc(member);
         validateIngredientProperties(ingredients);
         return ingredients;
     }
 
     @Override
-    public List<Ingredient> getAllMajorCategoryIngredients(Long memberId, MajorCategory majorCategory) {
-        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndMajorCategoryOrderByCreatedAtDesc(memberId, majorCategory);
+    public List<Ingredient> getAllMajorCategoryIngredients(Member member, MajorCategory majorCategory) {
+        validateLoggedInMember(member);
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_MemberAndMajorCategoryOrderByCreatedAtDesc(member, majorCategory);
         validateIngredientProperties(ingredients);
         return ingredients;
     }
 
     @Override
-    public List<Ingredient> getMajorCategoryIngredientsNearExpiry(Long memberId, MajorCategory majorCategory) {
-        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayAsc(memberId, majorCategory);
+    public List<Ingredient> getMajorCategoryIngredientsNearExpiry(Member member, MajorCategory majorCategory) {
+        validateLoggedInMember(member);
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_MemberAndMajorCategoryOrderByDDayAsc(member, majorCategory);
         validateIngredientProperties(ingredients);
         return ingredients;
     }
 
     @Override
-    public List<Ingredient> getMajorCategoryIngredientsFarExpiry(Long memberId, MajorCategory majorCategory) {
-        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndMajorCategoryOrderByDDayDesc(memberId, majorCategory);
+    public List<Ingredient> getMajorCategoryIngredientsFarExpiry(Member member, MajorCategory majorCategory) {
+        validateLoggedInMember(member);
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_MemberAndMajorCategoryOrderByDDayDesc(member, majorCategory);
         validateIngredientProperties(ingredients);
         return ingredients;
     }
 
     @Override
-    public List<Ingredient> getIngredientsByNameRecent(Long memberId, Optional<String> optSearch) {
-        findMemberById(memberId);
+    public List<Ingredient> getIngredientsByNameRecent(Member member, Optional<String> optSearch) {
+        validateLoggedInMember(member);
+        findMemberById(member.getMemberId());
         List<Ingredient> ingredients;
         if (optSearch.isPresent() && !optSearch.get().trim().isEmpty()) {
             String search = optSearch.get();
-            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(memberId, search);
+            ingredients = ingredientRepository.findAllByFridge_MemberAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(member, search);
         } else {
-            ingredients = ingredientRepository.findAllByFridge_MemberOrderByCreatedAtDesc(findMemberById(memberId));
+            ingredients = ingredientRepository.findAllByFridge_MemberOrderByCreatedAtDesc(member);
         }
         validateIngredientProperties(ingredients);
         return ingredients;
     }
 
     @Override
-    public List<Ingredient> getIngredientsByNameNearExpiry(Long memberId, Optional<String> optSearch) {
-        findMemberById(memberId);
+    public List<Ingredient> getIngredientsByNameNearExpiry(Member member, Optional<String> optSearch) {
+        validateLoggedInMember(member);
+        findMemberById(member.getMemberId());
         List<Ingredient> ingredients;
         if (optSearch.isPresent() && !optSearch.get().trim().isEmpty()) {
             String search = optSearch.get();
-            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayAsc(memberId, search);
+            ingredients = ingredientRepository.findAllByFridge_MemberAndIngredientNameContainingIgnoreCaseOrderByDDayAsc(member, search);
         } else {
-            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayAsc(memberId);
+            ingredients = ingredientRepository.findAllByFridge_MemberOrderByDDayAsc(member);
         }
         validateIngredientProperties(ingredients);
         return ingredients;
     }
 
     @Override
-    public List<Ingredient> getIngredientsByNameFarExpiry(Long memberId, Optional<String> optSearch) {
-        findMemberById(memberId);
+    public List<Ingredient> getIngredientsByNameFarExpiry(Member member, Optional<String> optSearch) {
+        validateLoggedInMember(member);
+        findMemberById(member.getMemberId());
         List<Ingredient> ingredients;
         if (optSearch.isPresent() && !optSearch.get().trim().isEmpty()) {
             String search = optSearch.get();
-            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByDDayDesc(memberId, search);
+            ingredients = ingredientRepository.findAllByFridge_MemberAndIngredientNameContainingIgnoreCaseOrderByDDayDesc(member, search);
         } else {
-            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByDDayDesc(memberId);
+            ingredients = ingredientRepository.findAllByFridge_MemberOrderByDDayDesc(member);
         }
         validateIngredientProperties(ingredients);
         return ingredients;

--- a/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/FridgeService/FridgeQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.backend.DuruDuru.global.service.FridgeService;
 
+import com.backend.DuruDuru.global.apiPayload.code.status.ErrorStatus;
+import com.backend.DuruDuru.global.apiPayload.exception.AuthException;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
 import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
@@ -33,9 +35,10 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
     }
 
     @Override
-    public List<Ingredient> getAllIngredients(Long memberId) {
-        findMemberById(memberId);
-        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(memberId);
+    public List<Ingredient> getAllIngredients(Member member) {
+        validateLoggedInMember(member);
+        findMemberById(member.getMemberId());
+        List<Ingredient> ingredients = ingredientRepository.findAllByFridge_MemberOrderByCreatedAtDesc(member);
         validateIngredientProperties(ingredients);
         return ingredients;
     }
@@ -85,7 +88,7 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
             String search = optSearch.get();
             ingredients = ingredientRepository.findAllByFridge_Member_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(memberId, search);
         } else {
-            ingredients = ingredientRepository.findAllByFridge_Member_MemberIdOrderByCreatedAtDesc(memberId);
+            ingredients = ingredientRepository.findAllByFridge_MemberOrderByCreatedAtDesc(findMemberById(memberId));
         }
         validateIngredientProperties(ingredients);
         return ingredients;
@@ -119,6 +122,12 @@ public class FridgeQueryServiceImpl implements FridgeQueryService {
         return ingredients;
     }
 
+    // 로그인 여부 확인
+    private void validateLoggedInMember(Member member) {
+        if (member == null) {
+            throw new AuthException(ErrorStatus.LOGIN_REQUIRED);
+        }
+    }
 
     // 식재료 필수 속성 미설정 예외처리 (카테고리, 보관방식, 구매날짜, 소비기한)
     private void validateIngredientProperties(List<Ingredient> ingredients) {

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -3,13 +3,16 @@ package com.backend.DuruDuru.global.web.controller;
 import com.backend.DuruDuru.global.converter.FridgeConverter;
 import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
+import com.backend.DuruDuru.global.security.handler.annotation.AuthUser;
 import com.backend.DuruDuru.global.service.FridgeService.FridgeQueryService;
 import com.backend.DuruDuru.global.web.dto.Fridge.FridgeResponseDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
 import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,8 +36,8 @@ public class FridgeController {
     // 전체 식재료 리스트 조회 (최신 등록순)
     @GetMapping("/recent")
     @Operation(summary = "최신 등록된 순으로 전체 식재료 리스트 조회 API", description = "사용자의 냉장고에 최신 등록된 순으로 전체 식재료 리스트를 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentIngredients(@RequestParam Long memberId) {
-        List<Ingredient> ingredients = fridgeQueryService.getAllIngredients(memberId);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentIngredients(@Parameter(name = "user", hidden = true) @AuthUser Member member) {
+        List<Ingredient> ingredients = fridgeQueryService.getAllIngredients(member);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -44,64 +44,64 @@ public class FridgeController {
     // 소비기한 임박순 식재료 리스트 조회
     @GetMapping("/near-expiry")
     @Operation(summary = "식재료 소비기한 임박순 리스트 조회 API", description = "식재료 리스트를 소비기한이 임박한 순서대로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientsNearExpiry(@RequestParam Long memberId) {
-        List<Ingredient> ingredients = fridgeQueryService.getIngredientsNearExpiry(memberId);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientsNearExpiry(@Parameter(name = "user", hidden = true) @AuthUser Member member) {
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsNearExpiry(member);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 소비기한 여유순 식재료 리스트 조회
     @GetMapping("/far-expiry")
     @Operation(summary = "식재료 소비기한 여유순 리스트 조회 API", description = "식재료 리스트를 소비기한이 여유로운 순서대로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientsFarExpiry(@RequestParam Long memberId) {
-        List<Ingredient> ingredients = fridgeQueryService.getIngredientsFarExpiry(memberId);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> ingredientsFarExpiry(@Parameter(name = "user", hidden = true) @AuthUser Member member) {
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsFarExpiry(member);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 대분류 기준 식재료 최신 등록순 리스트 조회
     @GetMapping("/majorCategory/recent")
     @Operation(summary = "대분류 기준 식재료 최신 등록순 리스트 조회 API", description = "대분류 기준 사용자의 냉장고에 최신 등록된 순으로 전체 식재료 리스트를 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentMajorCategoryIngredients(@RequestParam Long memberId, @RequestParam MajorCategory majorCategory) {
-        List<Ingredient> ingredients = fridgeQueryService.getAllMajorCategoryIngredients(memberId, majorCategory);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentMajorCategoryIngredients(@Parameter(name = "user", hidden = true) @AuthUser Member member, @RequestParam MajorCategory majorCategory) {
+        List<Ingredient> ingredients = fridgeQueryService.getAllMajorCategoryIngredients(member, majorCategory);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 대분류 기준 식재료 소비기한 임박순 리스트 조회
     @GetMapping("/majorCategory/near-expiry")
     @Operation(summary = "대분류 기준 식재료 소비기한 임박순 리스트 조회 API", description = "대분류 기준 식재료 리스트를 소비기한이 임박한 순서대로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> majorCategoryIngredientsNearExpiry(@RequestParam Long memberId, @RequestParam MajorCategory majorCategory) {
-        List<Ingredient> ingredients = fridgeQueryService.getMajorCategoryIngredientsNearExpiry(memberId, majorCategory);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> majorCategoryIngredientsNearExpiry(@Parameter(name = "user", hidden = true) @AuthUser Member member, @RequestParam MajorCategory majorCategory) {
+        List<Ingredient> ingredients = fridgeQueryService.getMajorCategoryIngredientsNearExpiry(member, majorCategory);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 대분류 기준 식재료 소비기한 여유순 리스트 조회
     @GetMapping("/majorCategory/far-expiry")
     @Operation(summary = "대분류 기준 식재료 소비기한 여유순 리스트 조회 API", description = "대분류 기준 식재료 리스트를 소비기한이 여유로운 순서대로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> majorCategoryIngredientsFarExpiry(@RequestParam Long memberId, @RequestParam MajorCategory majorCategory) {
-        List<Ingredient> ingredients = fridgeQueryService.getMajorCategoryIngredientsFarExpiry(memberId, majorCategory);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> majorCategoryIngredientsFarExpiry(@Parameter(name = "user", hidden = true) @AuthUser Member member, @RequestParam MajorCategory majorCategory) {
+        List<Ingredient> ingredients = fridgeQueryService.getMajorCategoryIngredientsFarExpiry(member, majorCategory);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 식재료 이름으로 검색 (최신 등록순)
     @GetMapping("/name/recent")
     @Operation(summary = "식재료 이름으로 검색 (최신 등록순) API", description = "식재료 이름으로 검색하여 최신 등록된 순으로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameRecent(@RequestParam Long memberId, @RequestParam Optional<String> search) {
-        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameRecent(memberId, search);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameRecent(@Parameter(name = "user", hidden = true) @AuthUser Member member, @RequestParam Optional<String> search) {
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameRecent(member, search);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 식재료 이름으로 검색 (소비기한 임박순)
     @GetMapping("/name/near-expiry")
     @Operation(summary = "식재료 이름으로 검색 (소비기한 임박순) API", description = "식재료 이름으로 검색하여 소비기한이 임박한 순으로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameNearExpiry(@RequestParam Long memberId, @RequestParam Optional<String> search) {
-        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameNearExpiry(memberId, search);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameNearExpiry(@Parameter(name = "user", hidden = true) @AuthUser Member member, @RequestParam Optional<String> search) {
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameNearExpiry(member, search);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 
     // 식재료 이름으로 검색 (소비기한 여유순)
     @GetMapping("/name/far-expiry")
     @Operation(summary = "식재료 이름으로 검색 (소비기한 여유순) API", description = "식재료 이름으로 검색하여 소비기한이 여유로운 순으로 조회하는 API 입니다.")
-    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameFarExpiry(@RequestParam Long memberId, @RequestParam Optional<String> search) {
-        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameFarExpiry(memberId, search);
+    public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findByNameFarExpiry(@Parameter(name = "user", hidden = true) @AuthUser Member member, @RequestParam Optional<String> search) {
+        List<Ingredient> ingredients = fridgeQueryService.getIngredientsByNameFarExpiry(member, search);
         return ApiResponse.onSuccess(SuccessStatus.FRIDGE_OK, FridgeConverter.toIngredientDetailListDTO(ingredients));
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/FridgeController.java
@@ -55,7 +55,7 @@ public class FridgeController {
     }
 
     // 대분류 기준 식재료 최신 등록순 리스트 조회
-    @GetMapping("/majorCategor/recent")
+    @GetMapping("/majorCategory/recent")
     @Operation(summary = "대분류 기준 식재료 최신 등록순 리스트 조회 API", description = "대분류 기준 사용자의 냉장고에 최신 등록된 순으로 전체 식재료 리스트를 조회하는 API 입니다.")
     public ApiResponse<FridgeResponseDTO.IngredientDetailListDTO> findAllRecentMajorCategoryIngredients(@RequestParam Long memberId, @RequestParam MajorCategory majorCategory) {
         List<Ingredient> ingredients = fridgeQueryService.getAllMajorCategoryIngredients(memberId, majorCategory);

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -47,8 +47,7 @@ public class IngredientController {
     // 식재료 카테고리 설정
     @PostMapping("/{ingredient_id}/category")
     @Operation(summary = "식재료 카테고리 설정 API", description = "식재료의 대분류와 소분류를 설정하는 API 입니다.")
-    public ApiResponse<?> setIngredientCategory(@RequestParam Long memberId,
-                                                @PathVariable("ingredient_id") Long ingredientId,
+    public ApiResponse<?> setIngredientCategory(@RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId,
                                                 @RequestBody @Valid IngredientRequestDTO.SetCategoryRequestDTO request) {
         log.info("SetCategoryRequestDTO: {}", request);
         Ingredient ingredient = ingredientCommandService.setCategory(memberId, ingredientId, request);
@@ -59,7 +58,7 @@ public class IngredientController {
     @PostMapping("/{ingredient_id}/storage-type")
     @Operation(summary = "식재료 보관 방식 설정 API", description = "식재료의 보관 방식을 설정하는 API 입니다.")
     public ApiResponse<IngredientResponseDTO.StorageTypeResultDTO> ingredientStorageType(@RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId,
-                                                @RequestBody IngredientRequestDTO.StorageTypeRequestDTO request) {
+                                                                                         @RequestBody IngredientRequestDTO.StorageTypeRequestDTO request) {
         Ingredient ingredient = ingredientCommandService.setStorageType(memberId, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toStorageTypeResultDTO(ingredient));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #100

## 📝작업 내용
> 냉장고 관련 API 인증 방식을 AuthUser 기반으로 변경

## 🔎코드 설명 및 참고 사항
> - 기존 API 호출 방식에서 AuthUser 어노테이션을 적용하여 자동으로 인증된 사용자 정보를 받아오도록 수정
> - 불필요한 memberId 요청 파라미터 제거 및 관련 메서드 시그니처 수정
<img width="40%" alt="스크린샷 2025-02-13 오후 3 14 05" src="https://github.com/user-attachments/assets/65449780-2b9e-49b7-aaba-f962b71c5d31" />

## 💬리뷰 요구사항
>
