### PR TITLE
Refactor: 식재료 및 OCR 관련 API 인증 방식을 AuthUser 기반으로 변경

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/IngredientRepository.java
@@ -12,12 +12,12 @@ import java.util.List;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
-    List<Ingredient> findByMember_MemberIdAndMinorCategory(Long memberId, MinorCategory minorCategory);
-    List<Ingredient> findByMember_MemberIdAndMajorCategory(Long memberId, MajorCategory majorCategory);
+    List<Ingredient> findByMemberAndMinorCategory(Member member, MinorCategory minorCategory);
+    List<Ingredient> findByMemberAndMajorCategory(Member member, MajorCategory majorCategory);
     // 사용자가 등록한 식재료 중 검색어가 포함된 식재료 조회 (대소문자 무시)
-    List<Ingredient> findAllByMember_MemberIdAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(Long memberId, String search);
+    List<Ingredient> findAllByMemberAndIngredientNameContainingIgnoreCaseOrderByCreatedAtDesc(Member member, String search);
     // 사용자가 등록한 모든 식재료 최신순 조회
-    List<Ingredient> findAllByMember_MemberIdOrderByCreatedAtDesc(Long memberId);
+    List<Ingredient> findAllByMemberOrderByCreatedAtDesc(Member member);
 
 
     // -- 냉장고 관련 -- //

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandService.java
@@ -2,19 +2,20 @@ package com.backend.DuruDuru.global.service.IngredientService;
 
 import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
 
 public interface IngredientCommandService {
 
-    Ingredient createRawIngredient(Long memberId, IngredientRequestDTO.CreateRawIngredientDTO request);
-    Ingredient updateIngredient(Long memberId, Long ingredientId, IngredientRequestDTO.UpdateIngredientDTO request);
-    void deleteIngredient(Long memberId, Long ingredientId);
+    Ingredient createRawIngredient(Member member, IngredientRequestDTO.CreateRawIngredientDTO request);
+    Ingredient updateIngredient(Member member, Long ingredientId, IngredientRequestDTO.UpdateIngredientDTO request);
+    void deleteIngredient(Member member, Long ingredientId);
 
-    Ingredient registerPurchaseDate(Long memberId, Long ingredientId, IngredientRequestDTO.PurchaseDateRequestDTO request);
-    Ingredient registerExpiryDate(Long memberId, Long ingredientId, IngredientRequestDTO.ExpiryDateRequestDTO request);
-    Ingredient setStorageType(Long memberId, Long ingredientId, IngredientRequestDTO.StorageTypeRequestDTO request);
+    Ingredient registerPurchaseDate(Member member, Long ingredientId, IngredientRequestDTO.PurchaseDateRequestDTO request);
+    Ingredient registerExpiryDate(Member member, Long ingredientId, IngredientRequestDTO.ExpiryDateRequestDTO request);
+    Ingredient setStorageType(Member member, Long ingredientId, IngredientRequestDTO.StorageTypeRequestDTO request);
 
-    Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request);
-    Ingredient setCategory(Long memberId, Long ingredientId, IngredientRequestDTO.SetCategoryRequestDTO request);
+    Ingredient registerIngredientImage(Member member, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request);
+    Ingredient setCategory(Member member, Long ingredientId, IngredientRequestDTO.SetCategoryRequestDTO request);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientCommandServiceImpl.java
@@ -2,7 +2,9 @@ package com.backend.DuruDuru.global.service.IngredientService;
 
 import com.backend.DuruDuru.global.S3.AmazonS3Manager;
 import com.backend.DuruDuru.global.apiPayload.ApiResponse;
+import com.backend.DuruDuru.global.apiPayload.code.status.ErrorStatus;
 import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
+import com.backend.DuruDuru.global.apiPayload.exception.AuthException;
 import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.*;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
@@ -55,8 +57,9 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
 
     @Override
     @Transactional
-    public Ingredient createRawIngredient(Long memberId, IngredientRequestDTO.CreateRawIngredientDTO request) {
-        Member member = findMemberById(memberId);
+    public Ingredient createRawIngredient(Member member, IngredientRequestDTO.CreateRawIngredientDTO request) {
+        validateLoggedInMember(member);
+        //Member member = findMemberById(memberId);
         Fridge fridge = findFridgeById(member.getFridgeId());
 
         Ingredient newIngredient = IngredientConverter.toIngredient(request);
@@ -70,8 +73,9 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
 
 
     @Override
-    public Ingredient updateIngredient(Long memberId, Long ingredientId, IngredientRequestDTO.UpdateIngredientDTO request) {
-        Member member = findMemberById(memberId);
+    public Ingredient updateIngredient(Member member, Long ingredientId, IngredientRequestDTO.UpdateIngredientDTO request) {
+        validateLoggedInMember(member);
+        //Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
 
         ingredient.update(request);
@@ -80,16 +84,18 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
     }
 
     @Override
-    public void deleteIngredient(Long memberId, Long ingredientId) {
-        Member member = findMemberById(memberId);
+    public void deleteIngredient(Member member, Long ingredientId) {
+        validateLoggedInMember(member);
+        //Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
 
         ingredientRepository.delete(ingredient);
     }
 
     @Override
-    public Ingredient registerPurchaseDate(Long memberId, Long ingredientId, IngredientRequestDTO.PurchaseDateRequestDTO request) {
-        Member member = findMemberById(memberId);
+    public Ingredient registerPurchaseDate(Member member, Long ingredientId, IngredientRequestDTO.PurchaseDateRequestDTO request) {
+        validateLoggedInMember(member);
+        //Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
 
         ingredient.setPurchaseDate(request.getPurchaseDate());
@@ -97,8 +103,9 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
     }
 
     @Override
-    public Ingredient registerExpiryDate(Long memberId, Long ingredientId, IngredientRequestDTO.ExpiryDateRequestDTO request) {
-        Member member = findMemberById(memberId);
+    public Ingredient registerExpiryDate(Member member, Long ingredientId, IngredientRequestDTO.ExpiryDateRequestDTO request) {
+        validateLoggedInMember(member);
+        //Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
 
         ingredient.setExpiryDate(request.getExpiryDate());
@@ -106,8 +113,9 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
     }
 
     @Override
-    public Ingredient setStorageType(Long memberId, Long ingredientId, IngredientRequestDTO.StorageTypeRequestDTO request) {
-        Member member = findMemberById(memberId);
+    public Ingredient setStorageType(Member member, Long ingredientId, IngredientRequestDTO.StorageTypeRequestDTO request) {
+        validateLoggedInMember(member);
+        //Member member = findMemberById(memberId);
         Ingredient ingredient = findIngredientById(ingredientId);
 
         ingredient.setStorageType(request.getStorageType());
@@ -117,7 +125,8 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
 
     @Transactional
     @Override
-    public Ingredient registerIngredientImage(Long memberId, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request) {
+    public Ingredient registerIngredientImage(Member member, Long ingredientId, IngredientRequestDTO.IngredientImageRequestDTO request) {
+        validateLoggedInMember(member);
         Ingredient ingredient = findIngredientById(ingredientId);
 
         if (ingredient.getIngredientImg() != null) {
@@ -146,7 +155,8 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
 
     @Transactional
     @Override
-    public Ingredient setCategory(Long memberId, Long ingredientId, IngredientRequestDTO.SetCategoryRequestDTO request) {
+    public Ingredient setCategory(Member member, Long ingredientId, IngredientRequestDTO.SetCategoryRequestDTO request) {
+        validateLoggedInMember(member);
         // 대분류 검증
         MajorCategory majorCategory;
         try {
@@ -179,6 +189,13 @@ public class IngredientCommandServiceImpl implements IngredientCommandService {
         ingredient.setStorageType(storageType); // 보관 방식 자동 설정 (사용자 변경가능)
 
         return ingredientRepository.save(ingredient);
+    }
+
+    // 로그인 여부 확인
+    private void validateLoggedInMember(Member member) {
+        if (member == null) {
+            throw new AuthException(ErrorStatus.LOGIN_REQUIRED);
+        }
     }
 
 

--- a/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/IngredientService/IngredientQueryService.java
@@ -1,6 +1,7 @@
 package com.backend.DuruDuru.global.service.IngredientService;
 
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
 
@@ -10,7 +11,7 @@ import java.util.Optional;
 
 public interface IngredientQueryService {
     Map<String, Object> getMinorCategoriesByMajor(MajorCategory majorCategory);
-    List<Ingredient> getIngredientsByMinorCategory(Long memberId, MinorCategory minorCategory);
-    List<Ingredient> getIngredientsByMajorCategory(Long memberId, MajorCategory majorCategory);
-    List<Ingredient> getIngredientsByName(Long memberId, Optional<String> optSearch);
+    List<Ingredient> getIngredientsByMinorCategory(Member member, MinorCategory minorCategory);
+    List<Ingredient> getIngredientsByMajorCategory(Member member, MajorCategory majorCategory);
+    List<Ingredient> getIngredientsByName(Member member, Optional<String> optSearch);
 }

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/IngredientController.java
@@ -4,13 +4,16 @@ import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
 import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.enums.MajorCategory;
 import com.backend.DuruDuru.global.domain.enums.MinorCategory;
+import com.backend.DuruDuru.global.security.handler.annotation.AuthUser;
 import com.backend.DuruDuru.global.service.IngredientService.IngredientCommandService;
 import com.backend.DuruDuru.global.service.IngredientService.IngredientQueryService;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,79 +42,86 @@ public class IngredientController {
     @PostMapping(path = "/{ingredient_id}/photo", consumes = "multipart/form-data")
     @Operation(summary = "추가할 식재료 사진 등록 API", description = "추가할 식재료의 사진을 등록하는 API 입니다.")
     public ApiResponse<IngredientResponseDTO.IngredientImageDTO> updateIngredientPhoto(@ModelAttribute IngredientRequestDTO.IngredientImageRequestDTO request,
-                                                                                       @RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId) {
-                Ingredient ingredient = ingredientCommandService.registerIngredientImage(memberId, ingredientId, request);
+                                                                                       @Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                                       @PathVariable("ingredient_id") Long ingredientId) {
+                Ingredient ingredient = ingredientCommandService.registerIngredientImage(member, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toIngredientImageDTO(ingredient));
     }
 
     // 식재료 카테고리 설정
     @PostMapping("/{ingredient_id}/category")
     @Operation(summary = "식재료 카테고리 설정 API", description = "식재료의 대분류와 소분류를 설정하는 API 입니다.")
-    public ApiResponse<?> setIngredientCategory(@RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId,
+    public ApiResponse<?> setIngredientCategory(@Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                @PathVariable("ingredient_id") Long ingredientId,
                                                 @RequestBody @Valid IngredientRequestDTO.SetCategoryRequestDTO request) {
         log.info("SetCategoryRequestDTO: {}", request);
-        Ingredient ingredient = ingredientCommandService.setCategory(memberId, ingredientId, request);
+        Ingredient ingredient = ingredientCommandService.setCategory(member, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toSetCategoryResultDTO(ingredient));
     }
 
     // 식재료 보관 방식 설정
     @PostMapping("/{ingredient_id}/storage-type")
     @Operation(summary = "식재료 보관 방식 설정 API", description = "식재료의 보관 방식을 설정하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.StorageTypeResultDTO> ingredientStorageType(@RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId,
+    public ApiResponse<IngredientResponseDTO.StorageTypeResultDTO> ingredientStorageType(@Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                                         @PathVariable("ingredient_id") Long ingredientId,
                                                                                          @RequestBody IngredientRequestDTO.StorageTypeRequestDTO request) {
-        Ingredient ingredient = ingredientCommandService.setStorageType(memberId, ingredientId, request);
+        Ingredient ingredient = ingredientCommandService.setStorageType(member, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toStorageTypeResultDTO(ingredient));
     }
 
     // 식재료 구매 날짜 등록
     @PostMapping("/{ingredient_id}/purchase-date")
     @Operation(summary = "식재료 구매 날짜 등록 API", description = "식재료의 구매 날짜를 등록하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.PurchaseDateResultDTO> registerPurchaseDate(@RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId,
+    public ApiResponse<IngredientResponseDTO.PurchaseDateResultDTO> registerPurchaseDate(@Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                                         @PathVariable("ingredient_id") Long ingredientId,
                                                                                          @RequestBody IngredientRequestDTO.PurchaseDateRequestDTO request){
-        Ingredient ingredient = ingredientCommandService.registerPurchaseDate(memberId, ingredientId, request);
+        Ingredient ingredient = ingredientCommandService.registerPurchaseDate(member, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toPurchaseDateResultDTO(ingredient));
     }
 
     // 식재료 소비기한 등록
     @PostMapping("/{ingredient_id}/expiry-date")
     @Operation(summary = "식재료 소비기한 등록 API", description = "식재료의 소비기한을 등록하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.ExpiryDateResultDTO> registerExpiryDate(@RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId,
+    public ApiResponse<IngredientResponseDTO.ExpiryDateResultDTO> registerExpiryDate(@Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                                     @PathVariable("ingredient_id") Long ingredientId,
                                                                                      @RequestBody IngredientRequestDTO.ExpiryDateRequestDTO request){
-        Ingredient ingredient = ingredientCommandService.registerExpiryDate(memberId, ingredientId, request);
+        Ingredient ingredient = ingredientCommandService.registerExpiryDate(member, ingredientId, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toExpiryDateResultDTO(ingredient));
     }
 
     // 식재료 직접 등록
     @PostMapping("/")
     @Operation(summary = "식재료 직접 등록 API", description = "식재료를 OCR 자동 인식 없이 직접 등록하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.CreateRawIngredientResultDTO> ingredientRawAdd(@RequestParam Long memberId,
+    public ApiResponse<IngredientResponseDTO.CreateRawIngredientResultDTO> ingredientRawAdd(@Parameter(name = "user", hidden = true) @AuthUser Member member,
                                                                                             @RequestBody IngredientRequestDTO.CreateRawIngredientDTO request) {
-        Ingredient newIngredient = ingredientCommandService.createRawIngredient(memberId, request);
+        Ingredient newIngredient = ingredientCommandService.createRawIngredient(member, request);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toCreateResultDTO(newIngredient));
     }
 
     // 식재료 정보 수정
     @PatchMapping("/{ingredient_id}")
     @Operation(summary = "식재료 정보 수정 API", description = "식재료의 정보를 수정하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.UpdateIngredientResultDTO> updateIngredient(@RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId,
+    public ApiResponse<IngredientResponseDTO.UpdateIngredientResultDTO> updateIngredient(@Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                                         @PathVariable("ingredient_id") Long ingredientId,
                                                                                          @RequestBody IngredientRequestDTO.UpdateIngredientDTO request){
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK,
-                IngredientConverter.UpdateIngredientResultDTO(ingredientCommandService.updateIngredient(memberId, ingredientId, request)));
+                IngredientConverter.UpdateIngredientResultDTO(ingredientCommandService.updateIngredient(member, ingredientId, request)));
     }
 
     // 식재료 삭제
     @DeleteMapping("/{ingredient_id}")
     @Operation(summary = "식재료 삭제 API", description = "식재료를 삭제하는 API 입니다.")
-    public ApiResponse<?> deleteIngredient(@RequestParam Long memberId, @PathVariable("ingredient_id") Long ingredientId){
-        ingredientCommandService.deleteIngredient(memberId, ingredientId);
+    public ApiResponse<?> deleteIngredient(@Parameter(name = "user", hidden = true) @AuthUser Member member, @PathVariable("ingredient_id") Long ingredientId){
+        ingredientCommandService.deleteIngredient(member, ingredientId);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, null);
     }
 
     // 식재료 이름으로 검색
     @GetMapping("/search/name")
     @Operation(summary = "식재료 이름으로 검색 API", description = "식재료를 이름으로 검색하는 API 입니다. 입력된 키워드가 포함된 식재료를 모두 반환하며, 검색어가 없을 경우 전체 식재료 등록순으로 반환합니다.")
-    public ApiResponse<IngredientResponseDTO.IngredientDetailListDTO> searchIngredientByName(@RequestParam Long memberId, @RequestParam Optional<String> search){
-        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByName(memberId, Optional.of(search.orElse("")));
+    public ApiResponse<IngredientResponseDTO.IngredientDetailListDTO> searchIngredientByName(@Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                                             @RequestParam Optional<String> search){
+        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByName(member, Optional.of(search.orElse("")));
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toIngredientDetailListDTO(ingredients));
     }
 
@@ -146,18 +156,18 @@ public class IngredientController {
     // 소분류 카테고리에 속하는 식재료 리스트 조회
     @GetMapping("/minorCategory/list")
     @Operation(summary = "소분류 카테고리에 속하는 식재료 리스트 조회 API", description = "소분류 카테고리에 속하는 식재료 리스트 조회하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.MinorCategoryIngredientPreviewListDTO> searchIngredientByMinorCategory(@RequestParam Long memberId,
+    public ApiResponse<IngredientResponseDTO.MinorCategoryIngredientPreviewListDTO> searchIngredientByMinorCategory(@Parameter(name = "user", hidden = true) @AuthUser Member member,
                                                                                                                     @RequestParam MinorCategory minorCategory) {
-        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByMinorCategory(memberId, minorCategory);
+        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByMinorCategory(member, minorCategory);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toMinorCategoryIngredientPreviewListDTO(minorCategory, ingredients));
     }
 
     // 대분류 카테고리에 속하는 식재료 리스트 조회
     @GetMapping("/majorCategory/list")
     @Operation(summary = "대분류 카테고리에 속하는 식재료 리스트 조회 API", description = "대분류 카테고리에 속하는 식재료 리스트 조회하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.MajorCategoryIngredientPreviewListDTO> searchIngredientByMajorCategory(@RequestParam Long memberId,
+    public ApiResponse<IngredientResponseDTO.MajorCategoryIngredientPreviewListDTO> searchIngredientByMajorCategory(@Parameter(name = "user", hidden = true) @AuthUser Member member,
                                                                                                                     @RequestParam MajorCategory majorCategory){
-        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByMajorCategory(memberId, majorCategory);
+        List<Ingredient> ingredients = ingredientQueryService.getIngredientsByMajorCategory(member, majorCategory);
         return ApiResponse.onSuccess(SuccessStatus.INGREDIENT_OK, IngredientConverter.toMajorCategoryIngredientPreviewListDTO(majorCategory, ingredients));
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/OCRController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/OCRController.java
@@ -4,11 +4,14 @@ import com.backend.DuruDuru.global.apiPayload.ApiResponse;
 import com.backend.DuruDuru.global.apiPayload.code.status.SuccessStatus;
 import com.backend.DuruDuru.global.converter.IngredientConverter;
 import com.backend.DuruDuru.global.domain.entity.Ingredient;
+import com.backend.DuruDuru.global.domain.entity.Member;
 import com.backend.DuruDuru.global.domain.entity.Receipt;
+import com.backend.DuruDuru.global.security.handler.annotation.AuthUser;
 import com.backend.DuruDuru.global.service.OCRService.ClovaOCRReceiptService;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Ingredient.IngredientResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,38 +33,30 @@ public class OCRController {
 
     private final ClovaOCRReceiptService clovaOCRReceiptService;
 
-//    @Operation(summary = "영수증 이미지 업로드", description = "영수증 이미지를 업로드하여 상품명을 추출합니다.")
-//    @PostMapping(value = "/receipt", consumes = "multipart/form-data")
-//    public ApiResponse<List<String>> processReceipt(@RequestParam("Receipt") MultipartFile file) throws IOException {
-//        log.info("Received file: {}", file.getOriginalFilename());
-//
-//        List<String> productNames = clovaOCRReceiptService.extractProductNames(file);
-//
-//        log.info("Extracted product names: {}", productNames);
-//        return ApiResponse.onSuccess(SuccessStatus.OCR_OK, productNames);
-//    }
-
     @PostMapping(value = "/receipt", consumes = "multipart/form-data")
     @Operation(summary = "영수증 OCR 처리 및 식재료 저장 API", description = "영수증 이미지를 업로드하여 상품명을 추출하고, 저장된 모든 식재료를 반환합니다.")
-    public ApiResponse<IngredientResponseDTO.IngredientOCRDetailListDTO> ingredientOcrAdd(@RequestParam Long memberId, @RequestParam("file") MultipartFile file) throws IOException {
-        List<Ingredient> savedIngredients = clovaOCRReceiptService.extractAndCategorizeProductNames(file, memberId);
+    public ApiResponse<IngredientResponseDTO.IngredientOCRDetailListDTO> ingredientOcrAdd(@Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                                          @RequestParam("file") MultipartFile file) throws IOException {
+        List<Ingredient> savedIngredients = clovaOCRReceiptService.extractAndCategorizeProductNames(file, member);
 
         return ApiResponse.onSuccess(SuccessStatus.OCR_OK, IngredientConverter.toIngredientOCRDetailListDTO(savedIngredients));
     }
 
     @PatchMapping(value = "/ingredient/{ingredient_id}")
     @Operation (summary = "OCR 인식된 식재료 이름 및 수량 수정 API", description = "OCR 인식된 식재료 이름 및 수량을 수정하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.UpdateOCRIngredientResultDTO> ingredientOcrUpdate(@PathVariable("ingredient_id") Long ingredientId, @RequestParam Long memberId, Long receiptId,
-                                                                                         @RequestBody IngredientRequestDTO.UpdateOCRIngredientDTO request) {
-        Ingredient updateOCRIngredient = clovaOCRReceiptService.updateOCRIngredient(memberId, ingredientId, receiptId, request);
+    public ApiResponse<IngredientResponseDTO.UpdateOCRIngredientResultDTO> ingredientOcrUpdate(@PathVariable("ingredient_id") Long ingredientId, @RequestParam Long receiptId,
+                                                                                               @Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                                               @RequestBody IngredientRequestDTO.UpdateOCRIngredientDTO request) {
+        Ingredient updateOCRIngredient = clovaOCRReceiptService.updateOCRIngredient(member, ingredientId, receiptId, request);
         return ApiResponse.onSuccess(SuccessStatus.OCR_OK, IngredientConverter.UpdateOCRIngredientResultDTO(updateOCRIngredient));
     }
 
     @PatchMapping(value = "/{receipt_id}/purchase-date")
     @Operation(summary = "영수증 인식 식재료 구매 날짜 수정 API", description = "영수증 인식된 식재료의 구매 날짜를 수정하는 API 입니다.")
-    public ApiResponse<IngredientResponseDTO.UpdateOCRPurchaseDateResultDTO> updateOCRPurchaseDate(@PathVariable("receipt_id") Long receiptId, @RequestParam Long memberId,
+    public ApiResponse<IngredientResponseDTO.UpdateOCRPurchaseDateResultDTO> updateOCRPurchaseDate(@PathVariable("receipt_id") Long receiptId,
+                                                                                                   @Parameter(name = "user", hidden = true) @AuthUser Member member,
                                                                                                    @RequestBody IngredientRequestDTO.PurchaseDateRequestDTO request) {
-        Receipt updatePurchaseDate = clovaOCRReceiptService.updateOCRPurchaseDate(memberId, receiptId, request);
+        Receipt updatePurchaseDate = clovaOCRReceiptService.updateOCRPurchaseDate(member, receiptId, request);
         return ApiResponse.onSuccess(SuccessStatus.OCR_OK, IngredientConverter.toOCRPurchaseDateResultDTO(updatePurchaseDate));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #72

## 📝작업 내용
> 식재료 및 OCR 관련 API 인증 방식을 AuthUser 기반으로 변경

## 🔎코드 설명 및 참고 사항
> - 기존 API 호출 방식에서 AuthUser 어노테이션을 적용하여 자동으로 인증된 사용자 정보를 받아오도록 수정
> - 불필요한 memberId 요청 파라미터 제거 및 관련 메서드 시그니처 수정
<img width="40%" alt="스크린샷 2025-02-13 오후 3 14 05" src="https://github.com/user-attachments/assets/65449780-2b9e-49b7-aaba-f962b71c5d31" />

## 💬리뷰 요구사항
>
