### PR TITLE
Refactor: ios용 카카오 로그인 api 수정

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/service/MemberService/MemberCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/MemberService/MemberCommandService.java
@@ -12,4 +12,5 @@ public interface MemberCommandService {
     AuthResponseDTO.TokenRefreshResponse refreshToken(String refreshToken);
     AuthResponseDTO.OAuthResponse kakaoLogin(String code);
     AuthResponseDTO.OAuthResponse naverLogin(String code);
+    AuthResponseDTO.OAuthResponse kakaoLoginWithToken(String accessToken);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/MemberService/MemberCommandServiceImpl.java
@@ -43,6 +43,7 @@ public class MemberCommandServiceImpl implements MemberCommandService{
                 .orElseThrow(() -> new MemberException(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
+    @Override
     @Transactional
     public AuthResponseDTO.OAuthResponse kakaoLoginWithToken(String accessToken) {
         KakaoProfile kakaoProfile;

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/MemberController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/MemberController.java
@@ -26,10 +26,17 @@ public class MemberController {
     private final MemberCommandService memberService;
 
     // 카카오 로그인 API
-    @Operation(summary = "카카오 로그인 API", description = "카카오 로그인 및 회원가입을 진행하는 API 입니다.")
-    @GetMapping("/login/kakao")
-    public ApiResponse<AuthResponseDTO.OAuthResponse> kakaoLogin(@RequestParam("code") String code) {
-        return ApiResponse.onSuccess(SuccessStatus.USER_KAKAO_LOGIN_OK, memberService.kakaoLogin(code));
+//    @Operation(summary = "카카오 로그인 API", description = "카카오 로그인 및 회원가입을 진행하는 API 입니다.")
+//    @GetMapping("/login/kakao")
+//    public ApiResponse<AuthResponseDTO.OAuthResponse> kakaoLogin(@RequestParam("code") String code) {
+//        return ApiResponse.onSuccess(SuccessStatus.USER_KAKAO_LOGIN_OK, memberService.kakaoLogin(code));
+//    }
+
+    // iOS용 카카오 로그인 API
+    @Operation(summary = "iOS용 카카오 로그인 API", description = "iOS 카카오 SDK에서 직접 받은 액세스 토큰을 이용해 로그인하는 API입니다.")
+    @PostMapping("/login/kakao")
+    public ApiResponse<AuthResponseDTO.OAuthResponse> kakaoLoginWithToken(@RequestBody AuthRequestDTO.KakaoLoginRequest request) {
+        return ApiResponse.onSuccess(SuccessStatus.USER_KAKAO_LOGIN_OK, memberService.kakaoLoginWithToken(request.getAccessToken()));
     }
 
     // 네이버 로그인 API

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Member/AuthRequestDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Member/AuthRequestDTO.java
@@ -47,4 +47,13 @@ public class AuthRequestDTO {
         @JsonProperty("refresh_token")
         String refreshToken;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoLoginRequest {
+        private String accessToken;
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #197 

## 📝작업 내용
> 기존 프론트에서 code를 받고 code값으로 accessToken을 발급하는 형식에서
프론트에서 accessToken을 받고 이를 검증하는 식으로 변경

## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
