### PR TITLE
Feat: 찜하기 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/backend/DuruDuru/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/backend/DuruDuru/global/apiPayload/code/status/SuccessStatus.java
@@ -37,6 +37,7 @@ public enum SuccessStatus implements BaseCode {
     TRADE_LIKE_OK(HttpStatus.OK, "TRADE_3006", "찜하기를 설정하였습니다."),
     TRADE_LIKE_DELETE_OK(HttpStatus.OK, "TRADE_3007", "찜하기를 취소하였습니다"),
     TRADE_LIKE_COUNT_OK(HttpStatus.OK, "TRADE_3008", "찜하기 개수를 성공적으로 조회하였습니다."),
+    TRADE_LIKE_CHECK_OK(HttpStatus.OK, "TRADE_3009", "찜하기 여부를 성공적으로 조회하였습니다."),
 
     // 식재료 관련 응답
     INGREDIENT_OK(HttpStatus.OK, "INGREDIENT_4000", "성공입니다."),

--- a/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
+++ b/src/main/java/com/backend/DuruDuru/global/converter/TradeConverter.java
@@ -7,7 +7,7 @@ import com.backend.DuruDuru.global.domain.entity.Trade;
 import com.backend.DuruDuru.global.domain.enums.Status;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeRequestDTO;
 import com.backend.DuruDuru.global.web.dto.Trade.TradeResponseDTO;
-import org.springframework.data.domain.Page;
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 public class TradeConverter {
 
-    public static TradeResponseDTO.TradeDetailResultDTO toTradeDetailDTO(Trade trade) {
+    public static TradeResponseDTO.TradeDetailResultDTO toTradeDetailDTO(Trade trade, boolean isLiked) {
         return TradeResponseDTO.TradeDetailResultDTO.builder()
                 .tradeId(trade.getTradeId())
                 .memberId(trade.getMember().getMemberId())
@@ -28,6 +28,7 @@ public class TradeConverter {
                 .eupmyeondong(trade.getEupmyeondong())
                 .status(trade.getStatus())
                 .tradeType(trade.getTradeType())
+                .liked(isLiked)
                 .likeCount(trade.getLikeCount())
                 .tradeImgs(trade.getTradeImgs())
                 .createdAt(trade.getCreatedAt())
@@ -101,6 +102,14 @@ public class TradeConverter {
         return TradeResponseDTO.LikeCountResultDTO.builder()
                 .tradeId(trade.getTradeId())
                 .likeCount(trade.getLikeCount())
+                .build();
+    }
+
+    public static TradeResponseDTO.IsLikeResultDTO toIsLikedResultDTO(Member member, Long tradeId, boolean isLiked) {
+        return TradeResponseDTO.IsLikeResultDTO.builder()
+                .memberId(member.getMemberId())
+                .tradeId(tradeId)
+                .liked(isLiked)
                 .build();
     }
 }

--- a/src/main/java/com/backend/DuruDuru/global/repository/LikeTradeRepository.java
+++ b/src/main/java/com/backend/DuruDuru/global/repository/LikeTradeRepository.java
@@ -6,6 +6,7 @@ import com.backend.DuruDuru.global.domain.entity.Trade;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeTradeRepository extends JpaRepository<LikeTrade, Long> {
-
+    // 멤버와 품앗이로 찜하기 조회
     LikeTrade findByMemberAndTrade(Member member, Trade trade);
+    boolean existsByMemberAndTrade(Member member, Trade trade);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandService.java
@@ -9,7 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public interface TradeCommandService {
-    // Trade 엔티티를 저장하는 메서드
+    // 품앗이 게시글 등록
     Trade createTrade(Member member, Long ingredientId, TradeRequestDTO.CreateTradeRequestDTO request);
     // 품앗이 게시글 삭제
     void deleteTrade(Member member, Long tradeId);
@@ -19,4 +19,6 @@ public interface TradeCommandService {
     LikeTrade createLike(Member member, Long tradeId);
     // 찜하기 취소
     void deleteLike(Member member, Long tradeId);
+    // 찜하기 여부 확인
+    boolean isLiked(Member member, Long tradeId);
 }

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeCommandServiceImpl.java
@@ -27,13 +27,12 @@ public class TradeCommandServiceImpl implements TradeCommandService {
 
     private final TradeRepository tradeRepository;
     private final TradeImageRepository tradeImageRepository;
-    private final MemberRepository memberRepository;
     private final IngredientRepository ingredientRepository;
     private final LikeTradeRepository likeTradeRepository;
     private final UuidRepository uuidRepository;
     private final AmazonS3Manager s3Manager;
 
-    // Trade 엔티티를 저장하는 메서드
+    // 품앗이 게시글 등록
     @Override
     @Transactional
     public Trade createTrade(Member member, Long ingredientId, TradeRequestDTO.CreateTradeRequestDTO request) {
@@ -198,6 +197,7 @@ public class TradeCommandServiceImpl implements TradeCommandService {
         return likeTradeRepository.save(likeTrade);
     }
 
+    // 찜하기 취소
     @Override
     @Transactional
     public void deleteLike(Member member, Long tradeId) {
@@ -212,6 +212,14 @@ public class TradeCommandServiceImpl implements TradeCommandService {
 
         trade.decreaseLikeCount();
         likeTradeRepository.delete(likeTrade);
+    }
+
+    // 찜하기 여부 조회
+    @Override
+    @Transactional
+    public boolean isLiked(Member member, Long tradeId) {
+        validateLoggedInMember(member);
+        return likeTradeRepository.existsByMemberAndTrade(member, findTradeById(tradeId));
     }
 
     // 로그인 여부 확인

--- a/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
+++ b/src/main/java/com/backend/DuruDuru/global/service/TradeService/TradeQueryServiceImpl.java
@@ -80,7 +80,6 @@ public class TradeQueryServiceImpl implements TradeQueryService {
     @Transactional
     public List<Trade> getOtherTrade(Member member, Long tradeId) {
         validateLoggedInMember(member);
-        Trade trade = findTradeById(tradeId);
         return tradeRepository.findOtherTrades(member.getTown().getLatitude(), member.getTown().getLongitude(), member.getMemberId(), tradeId, 4);
     }
 

--- a/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/controller/TradeController.java
@@ -46,7 +46,7 @@ public class TradeController {
             @ModelAttribute TradeRequestDTO.CreateTradeRequestDTO request
     ){
         Trade trade = tradeCommandService.createTrade(member, ingredientId, request);
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_CREATE_OK, TradeConverter.toTradeDetailDTO(trade));
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_CREATE_OK, TradeConverter.toTradeDetailDTO(trade, false));
     }
 
     // 품앗이 상세 조회
@@ -57,7 +57,7 @@ public class TradeController {
             @PathVariable("trade_id") Long tradeId
     ){
         Trade trade = tradeQueryService.getTrade(member, tradeId);
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_GET_DETAIL_OK, TradeConverter.toTradeDetailDTO(trade));
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_GET_DETAIL_OK, TradeConverter.toTradeDetailDTO(trade, tradeCommandService.isLiked(member, tradeId)));
     }
 
     // 품앗이 게시글 삭제
@@ -86,7 +86,7 @@ public class TradeController {
     ){
         TradeRequestDTO.UpdateTradeRequestDTO request = new TradeRequestDTO.UpdateTradeRequestDTO(ingredientCount, body, tradeType, status, deleteImgIds, addImgs);
         Trade trade = tradeCommandService.updateTrade(member, tradeId, request);
-        return ApiResponse.onSuccess(SuccessStatus.TRADE_UPDATE_OK, TradeConverter.toTradeDetailDTO(trade));
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_UPDATE_OK, TradeConverter.toTradeDetailDTO(trade, tradeCommandService.isLiked(member, tradeId)));
     }
 
     // 나의 활성화 품앗이 리스트 조회
@@ -181,6 +181,17 @@ public class TradeController {
     ) {
         LikeTrade likeTrade = tradeCommandService.createLike(member, tradeId);
         return ApiResponse.onSuccess(SuccessStatus.TRADE_LIKE_OK, TradeConverter.toLikeTradeResultDTO(likeTrade));
+    }
+
+    // 품앗이 찜하기 여부 조회
+    @GetMapping("/like/{trade_id}")
+    @Operation(summary = "품앗이 찜하기 여부 조회 API", description = "품앗이 찜하기 여부를 조회하는 API 입니다.")
+    public ApiResponse<TradeResponseDTO.IsLikeResultDTO> existLike(
+            @Parameter(name = "user", hidden = true) @AuthUser Member member,
+            @PathVariable("trade_id") Long tradeId
+    ) {
+        boolean isLiked = tradeCommandService.isLiked(member, tradeId);
+        return ApiResponse.onSuccess(SuccessStatus.TRADE_LIKE_CHECK_OK, TradeConverter.toIsLikedResultDTO(member, tradeId, isLiked));
     }
 
     // 품앗이 찜하기 취소

--- a/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
+++ b/src/main/java/com/backend/DuruDuru/global/web/dto/Trade/TradeResponseDTO.java
@@ -30,6 +30,7 @@ public class TradeResponseDTO {
         String eupmyeondong;
         Status status;
         TradeType tradeType;
+        boolean liked;
         Long likeCount;
         LocalDateTime createdAt;
         LocalDateTime updatedAt;
@@ -74,6 +75,16 @@ public class TradeResponseDTO {
         Long memberId;
         Long tradeId;
         Long likeCount;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class IsLikeResultDTO {
+        Long memberId;
+        Long tradeId;
+        boolean liked;
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈
> #157 

## 📝작업 내용
> 품앗이 찜하기 여부 조회 API 구현

## 🔎코드 설명 및 참고 사항
> - 품앗이 찜하기 여부 조회 API 구현
> - 품앗이 게시글 상세조회시, response에 liked를 추가하여 사용자의 찜하기 여부 확인

## 💬리뷰 요구사항
>
